### PR TITLE
Add String enum support

### DIFF
--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -76,19 +76,16 @@ private final class Impl {
         case .enum(let type):
             let genericParameters = type.genericParameters.map { $0.name }
             let ret = try EnumConverter(typeMap: typeMap).convert(type: type)
-            code.decls += [
+            code.decls += ret.typeDecls.map {
                 .typeDecl(
-                    name: ret.jsonTypeName,
+                    name: $0.typeName,
                     genericParameters: genericParameters,
-                    type: .union(ret.jsonType)
-                ),
-                .typeDecl(
-                    name: ret.taggedTypeName,
-                    genericParameters: genericParameters,
-                    type: .union(ret.taggedType)
-                ),
-                .custom(ret.decodeFunc)
-            ]
+                    type: .union($0.type)
+                )
+            }
+            if let decodeFunc = ret.decodeFunc {
+                code.decls += [.custom(decodeFunc)]
+            }
         case .struct(let type):
             let genericParameters = type.genericParameters.map { $0.name }
             let ret = try StructConverter(typeMap: typeMap).convert(type: type)

--- a/Tests/CodableToTypeScriptTests/EnumTranspileTests.swift
+++ b/Tests/CodableToTypeScriptTests/EnumTranspileTests.swift
@@ -74,6 +74,17 @@ enum E {
 """)
     }
 
+    func testTranspileString() throws {
+        try assertTranspile("""
+enum E: String, Codable {
+    case aaa
+    case bbb
+}
+""","""
+"aaa" | "bbb"
+""")
+    }
+
     private func assertTranspile(
         _ source: String,
         _ expected: String,

--- a/Tests/CodableToTypeScriptTests/GenerateTests.swift
+++ b/Tests/CodableToTypeScriptTests/GenerateTests.swift
@@ -87,6 +87,22 @@ export function EDecode<T>(json: EJSON<T>): E<T>
         )
     }
 
+    func testStringRawValueEnum() throws {
+        try assertGenerate(
+            source: """
+enum E: String, Codable {
+    case aaa
+    case iii
+}
+""",
+            type: "E",
+            expecteds: [
+                """
+export type E = "aaa" | "iii";
+""",
+            ]
+        )
+    }
 
     private func assertGenerate(
         source: String,


### PR DESCRIPTION
RawValueがStringのenumはTSのStringLiteralTypeのUnionとして表現できるようにします

```swift
enum E: String {
    case aa
    case ii
}
```

↓

```typescript
export type E = "aa" | "ii";
```