### PR TITLE
Remove 'JSON' suffix when the enum type has String rawValue.

### DIFF
--- a/Sources/CodableToTypeScript/Generator/StructConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/StructConverter.swift
@@ -56,7 +56,7 @@ final class StructConverter {
         if let mappedName = typeMap[type.name] {
             name = mappedName
         } else {
-            if let _ = type.enum {
+            if let enumType = type.enum, try !EnumConverter.isStringRawValueType(type: enumType) {
                 name += "JSON"
             }
         }

--- a/Tests/CodableToTypeScriptTests/CodableToTypeScriptTests.swift
+++ b/Tests/CodableToTypeScriptTests/CodableToTypeScriptTests.swift
@@ -69,13 +69,44 @@ export function EDecode(json: EJSON): E {
 """)
     }
 
+    func testEnumInStruct() throws {
+        try assertGenerate(
+            source: """
+enum E1 {
+    case a
+}
+
+enum E2: String {
+    case a
+}
+
+struct S {
+    var x: E1
+    var y: E2
+}
+""",
+            type: "S",
+            expected: """
+import {
+    E1JSON,
+    E2
+} from "..";
+
+export type S = {
+    x: E1JSON;
+    y: E2;
+};
+
+""")
+    }
+
     private func assertGenerate(
-        source: String, expected: String,
+        source: String, type: String? = nil, expected: String,
         file: StaticString = #file, line: UInt = #line
     ) throws {
         let tsCode = try Utils.generate(
             source: source,
-            type: { (_) in true },
+            type: { type ?? $0.name == $0.name },
             file: file, line: line
         )
         XCTAssertEqual(tsCode.description, expected)


### PR DESCRIPTION
#7 の対応は不十分だったので追加のPRになります

structのプロパティとしてenum型が生えている場合、一律`~JSON`というsuffixが付与されていましたが、このsuffixを付与する対応はRawValue==Stringなenumにとって不要（`~JSON`型が生成されないのでコンパイルエラーになる）であるため外します。

#### Swift Code

```swift
enum E1 {
    case a
}

enum E2: String {
    case a
}

struct S {
    var x: E1
    var y: E2
}
```

#### TypeScript Code (Before)

```ts
import {
    E1JSON,
    E2JSON
} from "..";

export type S = {
    x: E1JSON;
    y: E2JSON;
};
```

#### TypeScript Code (After)

```ts
import {
    E1JSON,
    E2
} from "..";

export type S = {
    x: E1JSON;
    y: E2;
};
```