### PR TITLE
nested typeのサポート

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "780ad8eb05a37fc5697159f16a2011f15cc24c54",
-        "version" : "1.1.0"
+        "revision" : "d5c434e6a13329cd9f2d3845f057f825cd99e5ef",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", .upToNextMinor(from: "1.1.0")),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", .upToNextMinor(from: "1.1.1")),
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Component/DependencyScanner.swift
+++ b/Sources/CodableToTypeScript/Component/DependencyScanner.swift
@@ -61,6 +61,8 @@ private final class Impl {
             for arg in t.genericArguments {
                 process(type: arg)
             }
+        case .nested(let t):
+            add(dep: t.namespace)
         case .record(let t):
             for field in t.fields {
                 process(type: field.type)

--- a/Sources/CodableToTypeScript/Generator/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/EnumConverter.swift
@@ -167,7 +167,7 @@ struct EnumConverter {
     private func transpile(associatedValue av: AssociatedValue, index: Int) throws -> TSRecordType.Field {
         let fieldName = Utils.label(of: av, index)
         let (type, isOptional) = try Utils.unwrapOptional(try av.type(), limit: 1)
-        let fieldType = try StructConverter.transpile(typeMap: typeMap, type: type)
+        let fieldType = try converter.transpileTypeReference(type)
 
         return .init(
             name: fieldName,

--- a/Sources/CodableToTypeScript/Generator/StructConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/StructConverter.swift
@@ -35,7 +35,7 @@ struct StructConverter {
         for property in type.storedProperties {
             let fieldName = property.name
             let (type, isOptional) = try Utils.unwrapOptional(try property.type(), limit: 1)
-            let fieldType = try Self.transpile(typeMap: typeMap, type: type)
+            let fieldType = try converter.transpileTypeReference(type)
 
             fields.append(
                 .init(name: fieldName, type: fieldType, isOptional: isOptional)
@@ -54,50 +54,4 @@ struct StructConverter {
         )
     }
 
-    static func transpile(typeMap: TypeMap, type: SType) throws -> TSType {
-        let (unwrappedFieldType, isWrapped) = try Utils.unwrapOptional(type, limit: nil)
-        if isWrapped {
-            let wrapped = try transpile(
-                typeMap: typeMap,
-                type: unwrappedFieldType
-            )
-            return .union([wrapped, .named("null")])
-        } else if let st = type.struct,
-                  st.name == "Array",
-                  try st.genericArguments().count >= 1
-        {
-            let element = try transpile(
-                typeMap: typeMap,
-                type: try st.genericArguments()[0]
-            )
-            return .array(element)
-        } else if let st = type.struct,
-                  st.name == "Dictionary",
-                  try st.genericArguments().count >= 2
-        {
-            let element = try transpile(
-                typeMap: typeMap,
-                type: try st.genericArguments()[1]
-            )
-            return .dictionary(element)
-        }
-
-        let specifier = type.asSpecifier()
-
-        let name: String
-
-        if let mappedName = typeMap.map(specifier: specifier) {
-            name = mappedName
-        } else if let enumType = type.enum {
-            name = try EnumConverter.transpiledName(type: enumType)
-        } else {
-            name = specifier.lastElement.name
-        }
-
-        let args = try type.genericArguments().map {
-            try transpile(typeMap: typeMap, type: $0)
-        }
-
-        return .named(name, genericArguments: args)
-    }
 }

--- a/Sources/TSCodeModule/Type/TSNamedType.swift
+++ b/Sources/TSCodeModule/Type/TSNamedType.swift
@@ -1,7 +1,7 @@
 public struct TSNamedType: PrettyPrintable {
     public init(
         _ name: String,
-        genericArguments: [TSType]
+        genericArguments: [TSType] = []
     ) {
         self.name = name
         self.genericArguments = genericArguments

--- a/Sources/TSCodeModule/Type/TSNestedType.swift
+++ b/Sources/TSCodeModule/Type/TSNestedType.swift
@@ -1,0 +1,14 @@
+public struct TSNestedType: PrettyPrintable {
+    public var namespace: String
+    public var type: TSType
+
+    public init(namespace: String, type: TSType) {
+        self.namespace = namespace
+        self.type = type
+    }
+
+    public func print(printer: PrettyPrinter) {
+        printer.write("\(namespace).")
+        type.print(printer: printer)
+    }
+}

--- a/Sources/TSCodeModule/Type/TSType.swift
+++ b/Sources/TSCodeModule/Type/TSType.swift
@@ -1,5 +1,6 @@
 public indirect enum TSType: PrettyPrintable {
     case named(TSNamedType)
+    case nested(TSNestedType)
     case record(TSRecordType)
     case union(TSUnionType)
     case array(TSArrayType)
@@ -9,6 +10,7 @@ public indirect enum TSType: PrettyPrintable {
     public func print(printer: PrettyPrinter) {
         switch self {
         case .named(let t): t.print(printer: printer)
+        case .nested(let t): t.print(printer: printer)
         case .record(let t): t.print(printer: printer)
         case .union(let t): t.print(printer: printer)
         case .array(let t): t.print(printer: printer)
@@ -19,6 +21,10 @@ public indirect enum TSType: PrettyPrintable {
 
     public static func named(_ name: String, genericArguments: [TSType] = []) -> TSType {
         .named(TSNamedType(name, genericArguments: genericArguments))
+    }
+
+    public static func nested(namespace: String, type: TSType) -> TSType {
+        .nested(TSNestedType(namespace: namespace, type: type))
     }
 
     public static func record(_ fields: [TSRecordType.Field]) -> TSType {

--- a/Tests/CodableToTypeScriptTests/GenerateTests.swift
+++ b/Tests/CodableToTypeScriptTests/GenerateTests.swift
@@ -201,8 +201,7 @@ export namespace A {
         )
     }
 
-    // TODO
-    func _testNestedTypeRef() throws {
+    func testNestedTypeRef() throws {
         try assertGenerate(
             source: """
 struct A {
@@ -214,7 +213,15 @@ struct C {
 }
 """,
             typeSelector: .name("C"),
-            expecteds: []
+            expecteds: ["""
+import {
+    A
+} from "..";
+""", """
+export type C = {
+    b: A.B;
+};
+"""]
         )
     }
 

--- a/Tests/TSCodeTests/TSCodeTests.swift
+++ b/Tests/TSCodeTests/TSCodeTests.swift
@@ -116,4 +116,13 @@ export namespace A {
 
         XCTAssertEqual(code.description, expected)
     }
+
+    func testNestedType() {
+        let t: TSNestedType = .init(
+            namespace: "A",
+            type: .named("B")
+        )
+
+        XCTAssertEqual(t.description, "A.B")
+    }
 }


### PR DESCRIPTION
#13 の対応

参照側の処理も作った。
Dependency Scanも修正して、ネームスペースをimportするようにした。

下記入力に対して、

```swift
struct A {
    struct B {}
}

struct C {
    var b: A.B
}
```

Aをトランスパイルすると以下が出る。

```ts
export type A = {};
export namespace A {
    export type B = {};
}
```

Cをトランスパイルすると以下が出て、Aの変換結果と一緒に使える。

```ts
import {
    A
} from "..";

export type C = {
    b: A.B;
};
```

