### PR TITLE
ジェネリック型がネストしたときのデコードのバグ修正

### DIFF
--- a/Sources/CodableToTypeScript/Generator/DecodeFunctionBuilder.swift
+++ b/Sources/CodableToTypeScript/Generator/DecodeFunctionBuilder.swift
@@ -105,6 +105,9 @@ struct DecodeFunctionBuilder {
         if let (_, _) = try type.asDictionary() {
             return try makeClosure()
         }
+        if try !type.genericArguments().isEmpty {
+            return try makeClosure()
+        }
         return .identifier(self.name(type: type))
     }
 

--- a/Sources/TSCodeModule/Expr/TSClosureExpr.swift
+++ b/Sources/TSCodeModule/Expr/TSClosureExpr.swift
@@ -19,10 +19,7 @@ public struct TSClosureExpr: PrettyPrintable {
             printer.write(": ")
             returnType.print(printer: printer)
         }
-        printer.writeLine(" => ")
+        printer.write(" => ")
         body.print(printer: printer)
-        if !printer.isStartOfLine {
-            printer.writeLine("")
-        }
     }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -403,4 +403,18 @@ export function E_decode<T, T_JSON>(json: E_JSON<T_JSON>, T_decode: (json: T_JSO
         )
     }
 
+    func testNestedGenericParameter() throws {
+        try assertGenerate(
+            source: """
+struct X<T> {
+    var a: T
+    var b: String
+}
+
+struct Y<T> {
+    var x: [X<T>]
+}
+""")
+    }
+
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -9,7 +9,7 @@ class GenerateTestCaseBase: XCTestCase {
         case all
     }
     // debug
-    var prints: Prints { .none }
+    var prints: Prints { .one }
 
     func assertGenerate(
         source: String,

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -9,7 +9,7 @@ class GenerateTestCaseBase: XCTestCase {
         case all
     }
     // debug
-    var prints: Prints { .one }
+    var prints: Prints { .none }
 
     func assertGenerate(
         source: String,


### PR DESCRIPTION
と、フォーマットが壊れていたところの修正