### PR TITLE
More smart PrettyPrinter formatting

### DIFF
--- a/Sources/TSCodeModule/Basic/PrettyPrinter.swift
+++ b/Sources/TSCodeModule/Basic/PrettyPrinter.swift
@@ -26,11 +26,13 @@ public final class PrettyPrinter {
 
     public private(set) var line: Int = 1
 
-    public private(set) var blockScope: BlockScope = .global
+    public private(set) var blockScope: BlockScope
 
     public var smallNumber: Int = 3
 
-    public init() {}
+    public init(initialScope: BlockScope = .global) {
+        blockScope = initialScope
+    }
 
     public func write(_ text: String) {
         indentIfStartOfLine()

--- a/Sources/TSCodeModule/Basic/PrettyPrinter.swift
+++ b/Sources/TSCodeModule/Basic/PrettyPrinter.swift
@@ -10,6 +10,15 @@ extension PrettyPrintable {
     }
 }
 
+public enum BlockScope {
+    case global
+    case function
+    case method
+    case `class`
+    case blockStmt
+    case interface
+}
+
 public final class PrettyPrinter {
     private var level: Int = 0
 
@@ -18,6 +27,8 @@ public final class PrettyPrinter {
     public private(set) var isStartOfLine: Bool = true
 
     public private(set) var line: Int = 1
+
+    public private(set) var blockScope: BlockScope = .global
 
     public var smallNumber: Int = 3
 
@@ -59,6 +70,13 @@ public final class PrettyPrinter {
     public func nest<R>(_ f: () throws -> R) rethrows -> R {
         push()
         defer { pop() }
+        return try f()
+    }
+
+    public func with<R>(blockScope: BlockScope, _ f: () throws -> R) rethrows -> R {
+        let prev = self.blockScope
+        defer { self.blockScope = prev }
+        self.blockScope = blockScope
         return try f()
     }
 

--- a/Sources/TSCodeModule/Basic/PrettyPrinter.swift
+++ b/Sources/TSCodeModule/Basic/PrettyPrinter.swift
@@ -13,9 +13,7 @@ extension PrettyPrintable {
 public enum BlockScope {
     case global
     case function
-    case method
     case `class`
-    case blockStmt
     case interface
 }
 

--- a/Sources/TSCodeModule/Code/TSBlockItem.swift
+++ b/Sources/TSCodeModule/Code/TSBlockItem.swift
@@ -41,10 +41,13 @@ extension [TSBlockItem] {
     public func print(printer: PrettyPrinter) {
         for (index, item) in enumerated() {
             if index > 0,
-               let decl = self[index - 1].decl,
-               decl.wantsTrailingNewline
+               let prevDecl = self[index - 1].decl,
+               let itemDecl = item.decl
             {
-                printer.writeLine("")
+                let isSame = isSameKind(lhs: prevDecl, rhs: itemDecl)
+                if !isSame || itemDecl.wantsNewlineBetweenSiblingDecl(scope: printer.blockScope) {
+                    printer.writeLine("")
+                }
             }
 
             item.print(printer: printer)

--- a/Sources/TSCodeModule/Code/TSCode.swift
+++ b/Sources/TSCodeModule/Code/TSCode.swift
@@ -8,6 +8,8 @@ public struct TSCode: PrettyPrintable {
     public var items: [TSBlockItem]
 
     public func print(printer: PrettyPrinter) {
-        items.print(printer: printer)
+        printer.with(blockScope: .global) {
+            items.print(printer: printer)
+        }
     }
 }

--- a/Sources/TSCodeModule/Decl/TSClassDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSClassDecl.swift
@@ -39,11 +39,11 @@ public struct TSClassDecl: PrettyPrintable {
         }
         printer.writeUnlessStartOfLine(" ")
         printer.writeLine("{")
-
-        printer.nest {
-            items.print(printer: printer)
+        printer.with(blockScope: .class) {
+            printer.nest {
+                items.print(printer: printer)
+            }
         }
-
         printer.writeLine("}")
     }
 }

--- a/Sources/TSCodeModule/Decl/TSDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSDecl.swift
@@ -20,16 +20,41 @@ public enum TSDecl: PrettyPrintable {
         case .method(let d): d.print(printer: r)
         case .namespace(let d): d.print(printer: r)
         case .type(let d): d.print(printer: r)
-        case .var(let d): d.print(printer: r)
+        case .`var`(let d): d.print(printer: r)
         case .custom(let d): d.print(printer: r)
         }
     }
 
-    public var wantsTrailingNewline: Bool {
+    public func wantsNewlineBetweenSiblingDecl(scope: BlockScope) -> Bool {
         switch self {
-        case .`var`(let d): return d.wantsTrailingNewline
-        case .custom: return false
-        default: return true
+        case .class:
+            return true
+        case .field:
+            return false
+        case .import:
+            return false
+        case .interface:
+            return true
+        case .method, .function:
+            switch scope {
+            case .interface:
+                return false
+            default:
+                return true
+            }
+        case .namespace:
+            return true
+        case .type:
+            return true
+        case .var:
+            switch scope {
+            case .global:
+                return true
+            default:
+                return false
+            }
+        case .custom:
+            return true
         }
     }
 
@@ -51,20 +76,45 @@ public enum TSDecl: PrettyPrintable {
         kind: String,
         name: String,
         type: TSType? = nil,
-        initializer: TSExpr? = nil,
-        wantsTrailingNewline: Bool = false
+        initializer: TSExpr? = nil
     ) -> TSDecl {
-        .var(TSVarDecl(
+        .`var`(TSVarDecl(
             export: export,
             kind: kind,
             name: name,
             type: type,
-            initializer: initializer,
-            wantsTrailingNewline: wantsTrailingNewline
+            initializer: initializer
         ))
     }
 
     public static func custom(_ text: String) -> TSDecl {
         .custom(TSCustomDecl(text))
+    }
+}
+
+public func isSameKind(lhs: TSDecl, rhs: TSDecl) -> Bool {
+    switch (lhs, rhs) {
+    case (.`class`, .`class`):
+        return true
+    case (.field, .field):
+        return true
+    case (.function, .function):
+        return true
+    case (.`import`, .`import`):
+        return true
+    case (.interface, .interface):
+        return true
+    case (.method, .method):
+        return true
+    case (.namespace, .namespace):
+        return true
+    case (.type, .type):
+        return true
+    case (.`var`, .`var`):
+        return true
+    case (.custom, .custom):
+        return false
+    default:
+        return false
     }
 }

--- a/Sources/TSCodeModule/Decl/TSFunctionDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSFunctionDecl.swift
@@ -37,8 +37,10 @@ public struct TSFunctionDecl: PrettyPrintable {
         }
 
         printer.writeLine(" {")
-        printer.nest {
-            items.print(printer: printer)
+        printer.with(blockScope: .function) {
+            printer.nest {
+                items.print(printer: printer)
+            }
         }
         printer.writeLine("}")
     }

--- a/Sources/TSCodeModule/Decl/TSImportDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSImportDecl.swift
@@ -8,16 +8,23 @@ public struct TSImportDecl: PrettyPrintable {
     public var from: String
 
     public func print(printer: PrettyPrinter) {
-        printer.writeLine("import {")
-        printer.nest {
-            for (i, name) in names.enumerated() {
-                printer.write(name)
-                if i < names.count - 1 {
-                    printer.write(",")
+        let isBig = names.count > printer.smallNumber
+        if isBig {
+            printer.writeLine("import {")
+            printer.nest {
+                for (i, name) in names.enumerated() {
+                    printer.write(name)
+                    if i < names.count - 1 {
+                        printer.write(",")
+                    }
+                    printer.writeLine("")
                 }
-                printer.writeLine("")
             }
+            printer.writeLine("} from \"\(from)\";")
+        } else {
+            printer.write("import { ")
+            printer.write(names.joined(separator: ", "))
+            printer.writeLine(" } from \"\(from)\";")
         }
-        printer.writeLine("} from \"\(from)\";")
     }
 }

--- a/Sources/TSCodeModule/Decl/TSInterfaceDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSInterfaceDecl.swift
@@ -32,8 +32,10 @@ public struct TSInterfaceDecl: PrettyPrintable {
         }
         printer.writeUnlessStartOfLine(" ")
         printer.writeLine("{")
-        printer.nest {
-            decls.map { TSBlockItem.decl($0) }.print(printer: printer)
+        printer.with(blockScope: .interface) {
+            printer.nest {
+                decls.map { TSBlockItem.decl($0) }.print(printer: printer)
+            }
         }
         printer.writeLine("}")
     }

--- a/Sources/TSCodeModule/Decl/TSMethodDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSMethodDecl.swift
@@ -44,7 +44,7 @@ public struct TSMethodDecl: PrettyPrintable {
 
         if let items {
             printer.writeLine(" {")
-            printer.with(blockScope: .method) {
+            printer.with(blockScope: .function) {
                 printer.nest {
                     items.print(printer: printer)
                 }

--- a/Sources/TSCodeModule/Decl/TSMethodDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSMethodDecl.swift
@@ -44,8 +44,10 @@ public struct TSMethodDecl: PrettyPrintable {
 
         if let items {
             printer.writeLine(" {")
-            printer.nest {
-                items.print(printer: printer)
+            printer.with(blockScope: .method) {
+                printer.nest {
+                    items.print(printer: printer)
+                }
             }
             printer.writeLine("}")
         } else {

--- a/Sources/TSCodeModule/Decl/TSVarDecl.swift
+++ b/Sources/TSCodeModule/Decl/TSVarDecl.swift
@@ -4,22 +4,19 @@ public struct TSVarDecl: PrettyPrintable {
     public var name: String
     public var type: TSType?
     public var initializer: TSExpr?
-    public var wantsTrailingNewline: Bool
 
     public init(
         export: Bool = false,
         kind: String,
         name: String,
         type: TSType? = nil,
-        initializer: TSExpr? = nil,
-        wantsTrailingNewline: Bool = false
+        initializer: TSExpr? = nil
     ) {
         self.export = export
         self.kind = kind
         self.name = name
         self.type = type
         self.initializer = initializer
-        self.wantsTrailingNewline = wantsTrailingNewline
     }
 
     public func print(printer: PrettyPrinter) {

--- a/Sources/TSCodeModule/Stmt/TSBlockStmt.swift
+++ b/Sources/TSCodeModule/Stmt/TSBlockStmt.swift
@@ -7,10 +7,8 @@ public struct TSBlockStmt: PrettyPrintable {
 
     public func print(printer: PrettyPrinter) {
         printer.writeLine("{")
-        printer.with(blockScope: .blockStmt) {
-            printer.nest {
-                items.print(printer: printer)
-            }
+        printer.nest {
+            items.print(printer: printer)
         }
         printer.write("}")
     }

--- a/Sources/TSCodeModule/Stmt/TSBlockStmt.swift
+++ b/Sources/TSCodeModule/Stmt/TSBlockStmt.swift
@@ -7,8 +7,10 @@ public struct TSBlockStmt: PrettyPrintable {
 
     public func print(printer: PrettyPrinter) {
         printer.writeLine("{")
-        printer.nest {
-            items.print(printer: printer)
+        printer.with(blockScope: .blockStmt) {
+            printer.nest {
+                items.print(printer: printer)
+            }
         }
         printer.write("}")
     }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
@@ -144,11 +144,7 @@ enum R<T> {
 }
 """,
         expecteds: ["""
-import {
-    E,
-    E_JSON,
-    E_decode
-} from "..";
+import { E, E_JSON, E_decode } from "..";
 """, """
 export type R<T> = {
     kind: "s";

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
@@ -101,9 +101,7 @@ struct C {
 """,
             typeSelector: .name("C"),
             expecteds: ["""
-import {
-    A_B
-} from "..";
+import { A_B } from "..";
 """, """
 export type C = {
     b: A_B;

--- a/Tests/TSCodeTests/TSCodeTests.swift
+++ b/Tests/TSCodeTests/TSCodeTests.swift
@@ -71,11 +71,7 @@ export type S1 = {
         let imp = TSImportDecl(names: ["A", "B", "C"], from: "..")
 
         let expected = """
-import {
-    A,
-    B,
-    C
-} from "..";
+import { A, B, C } from "..";
 
 """
         XCTAssertEqual(imp.description, expected)

--- a/Tests/TSCodeTests/TSCodeTests.swift
+++ b/Tests/TSCodeTests/TSCodeTests.swift
@@ -220,4 +220,97 @@ export class A extends B implements
 
 """)
     }
+
+    func testImports() {
+        let e: TSCode = .init([
+            .decl(.import(names: ["A", "B"], from: "./ab.js")),
+            .decl(.import(names: ["C"], from: "./c.js")),
+            .decl(.import(names: ["D", "E", "F", "G", "H", "I"], from: "./defghi.js")),
+            .decl(.function(.init(name: "foo", parameters: [], returnType: nil, items: [])))
+        ])
+        let expected = """
+import { A, B } from "./ab.js";
+import { C } from "./c.js";
+import {
+    D,
+    E,
+    F,
+    G,
+    H,
+    I
+} from "./defghi.js";
+
+export function foo() {
+}
+
+"""
+
+        XCTAssertEqual(e.description, expected)
+    }
+
+    func testNewLineBetweenDecls() {
+        let e: TSCode = .init([
+            .decl(.import(names: ["A", "B"], from: "./ab.js")),
+            .decl(.import(names: ["C"], from: "./c.js")),
+            .decl(.interface(.init(name: "I", decls: [
+                .field(.init(name: "value1", type: .named("A"))),
+                .field(.init(name: "value2", type: .named("B"))),
+                .method(.init(name: "f1", parameters: [], returnType: nil)),
+                .method(.init(name: "f2", parameters: [], returnType: nil)),
+            ]))),
+            .decl(.function(.init(name: "foo", parameters: [], returnType: nil, items: [
+                .decl(.var(kind: "const", name: "c1", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+                .decl(.var(kind: "const", name: "c2", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+            ]))),
+            .decl(.var(export: true, kind: "const", name: "c1", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+            .decl(.var(export: true, kind: "const", name: "c2", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+            .decl(.class(.init(name: "Bar", items: [
+                .decl(.field(.init(name: "value1", type: .named("A")))),
+                .decl(.field(.init(name: "value2", type: .named("B")))),
+                .decl(.function(.init(export: false, name: "f1", parameters: [], returnType: .named("string"), items: [
+                    .decl(.var(kind: "const", name: "c1", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+                    .decl(.var(kind: "const", name: "c2", type: .orUndefined(.named("C")), initializer: .identifier("undefined"))),
+                ]))),
+                .decl(.function(.init(export: false, name: "f2", parameters: [], returnType: .named("string"), items: [
+                ]))),
+            ])))
+        ])
+        let expected = """
+import { A, B } from "./ab.js";
+import { C } from "./c.js";
+
+export interface I {
+    value1: A;
+    value2: B;
+
+    f1();
+    f2();
+}
+
+export function foo() {
+    const c1: C | undefined = undefined;
+    const c2: C | undefined = undefined;
+}
+
+export const c1: C | undefined = undefined;
+
+export const c2: C | undefined = undefined;
+
+export class Bar {
+    value1: A;
+    value2: B;
+
+    function f1(): string {
+        const c1: C | undefined = undefined;
+        const c2: C | undefined = undefined;
+    }
+
+    function f2(): string {
+    }
+}
+
+"""
+
+        XCTAssertEqual(e.description, expected)
+    }
 }


### PR DESCRIPTION
https://github.com/sidepelican/CallableKit/pull/4 において言及した、生成コードフォーマットを改善します。
主に小さな1つの変更と、大きな1つの変更があります

## importDeclの分割

importする識別子の数に応じて改行の有無を変化させます

-  変更前 

```ts
import { 
    A,
    B
} from "./ab.js";

import { 
    C
} from "./c.js";

import {
    D,
    E,
    F,
    G,
    H,
    I
} from "./defghi.js";
```

- 変更後

```ts
import { A, B } from "./ab.js";

import { C } from "./c.js";

import {
    D,
    E,
    F,
    G,
    H,
    I
} from "./defghi.js";
```


## PrettyPrinterにスコープの概念の導入

PrettyPrinterに現在どのスコープで描画されているかのパラメータを与えることで、スコープに応じて上下のdeclとの間に改行を入れるかどうかを判断できるようにしました。
これにより自身とその上のdeclが同一種類のdeclだった場合に、改行を入れるべきかどうか判断できるようになりました。

- 変更前

```ts
import { A, B } from "./ab.js";

import { C } from "./c.js";

export interface I {
    value1: A;

    value2: B;

    f1();

    f2();
}

export function foo() {
    const c1: C | undefined = undefined;

    const c2: C | undefined = undefined;
}

export const c1: C | undefined = undefined;

export const c2: C | undefined = undefined;
```

- 変更後

```ts
import { A, B } from "./ab.js";
import { C } from "./c.js";

export interface I {
    value1: A;
    value2: B;

    f1();
    f2();
}

export function foo() {
    const c1: C | undefined = undefined;
    const c2: C | undefined = undefined;
}

export const c1: C | undefined = undefined;

export const c2: C | undefined = undefined;
```