### PR TITLE
Update SwiftTypeReader

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "6b1b8b72f2ffbdae48fc1dd214e3c8eff55c8e1c",
-        "version" : "1.1.3"
+        "revision" : "fb37c5bfeb4c97e8f3097d6df707c3b1f9cf9743",
+        "version" : "1.1.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", .upToNextMinor(from: "1.1.3")),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", .upToNextMinor(from: "1.1.4")),
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Extensions/STypeEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/STypeEx.swift
@@ -13,12 +13,12 @@ extension SType {
         return NamePath(parts)
     }
 
-    func unwrapOptional(limit: Int?) throws -> (wrapped: SType, depth: Int)? {
+    func unwrapOptional(limit: Int?) -> (wrapped: SType, depth: Int)? {
         var type = self
         var depth = 0
         while type.isStandardLibraryType("Optional"),
               let optional = type.struct,
-              let wrapped = try optional.genericArguments()[safe: 0]
+              let wrapped = optional.genericArguments()[safe: 0]
         {
             if let limit = limit,
                depth >= limit
@@ -34,30 +34,30 @@ extension SType {
         return (wrapped: type, depth: depth)
     }
 
-    func asArray() throws -> (array: StructType, element: SType)? {
+    func asArray() -> (array: StructType, element: SType)? {
         guard isStandardLibraryType("Array"),
               let array = self.struct,
-              let element = try array.genericArguments()[safe: 0] else { return nil }
+              let element = array.genericArguments()[safe: 0] else { return nil }
         return (array: array, element: element)
     }
 
-    func asDictionary() throws -> (dictionary: StructType, value: SType)? {
+    func asDictionary() -> (dictionary: StructType, value: SType)? {
         guard isStandardLibraryType("Dictionary"),
               let dict = self.struct,
-              let value = try dict.genericArguments()[safe: 1] else { return nil }
+              let value = dict.genericArguments()[safe: 1] else { return nil }
         return (dictionary: dict, value: value)
     }
 
     func isStandardLibraryType(_ name: String) -> Bool {
         guard let type = self.regular else { return false }
 
-        return type.location.elements == [.module(name: "Swift")] &&
+        return type.location.module == "Swift" &&
         type.name == name
     }
 
-    func hasStringRawValue() throws -> Bool {
+    func hasStringRawValue() -> Bool {
         guard let type = self.regular else { return false }
-        return try type.inheritedTypes().contains { (type) in
+        return type.inheritedTypes().contains { (type) in
             type.isStandardLibraryType("String")
         }
     }

--- a/Sources/CodableToTypeScript/Generator/DecodeFunctionBuilder.swift
+++ b/Sources/CodableToTypeScript/Generator/DecodeFunctionBuilder.swift
@@ -96,14 +96,14 @@ struct DecodeFunctionBuilder {
         if try c.hasEmptyDecoder(type: type) {
             return c.helperLibrary().access(.identityFunction)
         }
-        if try !type.genericArguments().isEmpty {
+        if !type.genericArguments().isEmpty {
             return try makeClosure()
         }
         return .identifier(self.name(type: type))
     }
 
     func decodeField(type: SType, expr: TSExpr) throws -> TSExpr {
-        if let (wrapped, _) = try type.unwrapOptional(limit: 1) {
+        if let (wrapped, _) = type.unwrapOptional(limit: 1) {
             if try c.hasEmptyDecoder(type: wrapped) { return expr }
             return try callHeigherOrderDecode(
                 types: [wrapped],
@@ -117,7 +117,7 @@ struct DecodeFunctionBuilder {
 
     func decodeValue(type: SType, expr: TSExpr) throws -> TSExpr {
         let lib = c.helperLibrary()
-        if let (wrapped, _) = try type.unwrapOptional(limit: nil) {
+        if let (wrapped, _) = type.unwrapOptional(limit: nil) {
             if try c.hasEmptyDecoder(type: wrapped) { return expr }
             return try callHeigherOrderDecode(
                 types: [wrapped],
@@ -125,7 +125,7 @@ struct DecodeFunctionBuilder {
                 json: expr
             )
         }
-        if let (_, element) = try type.asArray() {
+        if let (_, element) = type.asArray() {
             if try c.hasEmptyDecoder(type: element) { return expr }
             return try callHeigherOrderDecode(
                 types: [element],
@@ -133,7 +133,7 @@ struct DecodeFunctionBuilder {
                 json: expr
             )
         }
-        if let (_, value) = try type.asDictionary() {
+        if let (_, value) = type.asDictionary() {
             if try c.hasEmptyDecoder(type: value) { return expr }
             return try callHeigherOrderDecode(
                 types: [value],
@@ -148,7 +148,7 @@ struct DecodeFunctionBuilder {
 
         let decode: TSExpr = .identifier(self.name(type: type))
 
-        let typeArgs = try type.genericArguments()
+        let typeArgs = type.genericArguments()
         if typeArgs.count > 0 {
             return try callHeigherOrderDecode(
                 types: typeArgs,

--- a/Sources/CodableToTypeScript/Generator/EmptyDecodeEvaluator.swift
+++ b/Sources/CodableToTypeScript/Generator/EmptyDecodeEvaluator.swift
@@ -42,13 +42,13 @@ final class EmptyDecodeEvaluator {
             return true
         }
 
-        if let (wrapped, _) = try type.unwrapOptional(limit: nil) {
+        if let (wrapped, _) = type.unwrapOptional(limit: nil) {
             return try visit(type: wrapped, visiteds: visiteds)
         }
-        if let (_, element) = try type.asArray() {
+        if let (_, element) = type.asArray() {
             return try visit(type: element, visiteds: visiteds)
         }
-        if let (_, value) = try type.asDictionary() {
+        if let (_, value) = type.asDictionary() {
             return try visit(type: value, visiteds: visiteds)
         }
 
@@ -59,12 +59,12 @@ final class EmptyDecodeEvaluator {
         switch type {
         case .enum(let type):
             if type.caseElements.isEmpty { return true }
-            if try SType.enum(type).hasStringRawValue() { return true }
+            if SType.enum(type).hasStringRawValue() { return true }
             return false
         case .struct(let type):
             for field in type.storedProperties {
                 if try !visit(
-                    type: try field.type(),
+                    type: field.type(),
                     visiteds: visiteds
                 ) {
                     return false

--- a/Sources/CodableToTypeScript/Generator/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/EnumConverter.swift
@@ -15,7 +15,7 @@ struct EnumConverter {
                 genericParameters: genericParameters,
                 type: .named("never")
             )
-        } else if try SType.enum(type).hasStringRawValue() {
+        } else if SType.enum(type).hasStringRawValue() {
             let items: [TSType] = type.caseElements.map { (ce) in
                 .stringLiteral(ce.name)
             }
@@ -57,7 +57,7 @@ struct EnumConverter {
 
         for (index, av) in caseElement.associatedValues.enumerated() {
             let (type, isOptionalField) = try converter.transpileFieldTypeReference(
-                type: try av.type(), kind: kind
+                type: av.type(), kind: kind
             )
 
             innerFields.append(.init(
@@ -106,7 +106,7 @@ struct EnumConverter {
                 let label = value.label(index: index)
                 var expr: TSExpr = .memberAccess(base: json, name: label)
 
-                expr = try builder.decodeField(type: try value.type(), expr: expr)
+                expr = try builder.decodeField(type: value.type(), expr: expr)
 
                 let field = TSObjectField(
                     name: .identifier(label), value: expr

--- a/Sources/CodableToTypeScript/Generator/StructConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/StructConverter.swift
@@ -9,7 +9,7 @@ struct StructConverter {
 
         for property in type.storedProperties {
             let (type, isOptionalField) = try converter.transpileFieldTypeReference(
-                type: try property.type(), kind: kind
+                type: property.type(), kind: kind
             )
 
             fields.append(.init(
@@ -38,7 +38,7 @@ struct StructConverter {
                 name: field.name
             )
 
-            expr = try builder.decodeField(type: try field.type(), expr: expr)
+            expr = try builder.decodeField(type: field.type(), expr: expr)
 
             fields.append(
                 .init(

--- a/Sources/CodableToTypeScript/Generator/TypeConverter.swift
+++ b/Sources/CodableToTypeScript/Generator/TypeConverter.swift
@@ -81,7 +81,7 @@ final class TypeConverter {
     func transpileFieldTypeReference(type: SType, kind: TypeKind) throws -> (type: TSType, isOptionalField: Bool) {
         var type = type
         var isOptionalField = false
-        if let (wrapped, _) = try type.unwrapOptional(limit: 1) {
+        if let (wrapped, _) = type.unwrapOptional(limit: 1) {
             type = wrapped
             isOptionalField = true
         }
@@ -92,17 +92,17 @@ final class TypeConverter {
     }
 
     func transpileTypeReference(_ type: SType, kind: TypeKind) throws -> TSType {
-        if let (wrapped, _) = try type.unwrapOptional(limit: nil) {
+        if let (wrapped, _) = type.unwrapOptional(limit: nil) {
             return .orNull(
                 try transpileTypeReference(wrapped, kind: kind)
             )
         }
-        if let (_, element) = try type.asArray() {
+        if let (_, element) = type.asArray() {
             return .array(
                 try transpileTypeReference(element, kind: kind)
             )
         }
-        if let (_, value) = try type.asDictionary() {
+        if let (_, value) = type.asDictionary() {
             return .dictionary(
                 try transpileTypeReference(value, kind: kind)
             )

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -20,41 +20,43 @@ class GenerateTestCaseBase: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
-        let result = try Reader().read(source: source)
+        try withExtendedLifetime(Context()) { context in
+            let module = try Reader(context: context).read(source: source)
 
-        let gen = CodeGenerator(typeMap: typeMap ?? .default)
+            let gen = CodeGenerator(typeMap: typeMap ?? .default)
 
-        if case .all = prints {
-            for swType in result.module.types {
-                print("// \(swType.name)")
-                let code = try gen.generateTypeDeclarationFile(type: swType)
+            if case .all = prints {
+                for swType in module.types {
+                    print("// \(swType.name)")
+                    let code = try gen.generateTypeDeclarationFile(type: swType)
+                    print(code)
+                }
+            }
+
+            let swType = try typeSelector(module: module)
+            let code = try gen.generateTypeDeclarationFile(type: swType)
+
+            if case .one = prints {
                 print(code)
             }
-        }
 
-        let swType = try typeSelector(module: result.module)
-        let code = try gen.generateTypeDeclarationFile(type: swType)
+            let actual = code.description
 
-        if case .one = prints {
-            print(code)
-        }
-        
-        let actual = code.description
-
-        for expected in expecteds {
-            if !actual.contains(expected) {
-                XCTFail(
-                    "No expected text: \(expected)",
-                    file: file, line: line
-                )
+            for expected in expecteds {
+                if !actual.contains(expected) {
+                    XCTFail(
+                        "No expected text: \(expected)",
+                        file: file, line: line
+                    )
+                }
             }
-        }
-        for unexpected in unexpecteds {
-            if actual.contains(unexpected) {
-                XCTFail(
-                    "Unexpected text: \(unexpected)",
-                    file: file, line: line
-                )
+            for unexpected in unexpecteds {
+                if actual.contains(unexpected) {
+                    XCTFail(
+                        "Unexpected text: \(unexpected)",
+                        file: file, line: line
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
SwiftTypeReaderのバージョンをあげます。
いくつかコンパイルエラーと警告が出ていたので修正しました。

SwiftTypeReader側の修正をそれほど把握しておらず、コンパイルエラーに則って修正しただけです。そのため本質的にもっと削除できるロジックがあるのかもしれません。
コンパイルエラーと警告がすべて消え、テストが通るところまでの部分をやりました。