### PR TITLE
Update TypeScriptAST

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "8e3016ef6570bddbc080798895c8465c725f842e",
-        "version" : "1.1.1"
+        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.1.1")
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.2.0")
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -160,7 +160,7 @@ private struct DecodeFuncGen {
             expr = try generator.converter(for: value.interfaceType)
                 .callDecodeField(json: expr)
 
-            let field = TSObjectExpr.Field(
+            let field = TSObjectExpr.Field.named(
                 name: label, value: expr
             )
             fields.append(field)
@@ -184,11 +184,11 @@ private struct DecodeFuncGen {
         }
 
         let fields: [TSObjectExpr.Field] = [
-            .init(
+            .named(
                 name: "kind",
                 value: TSStringLiteralExpr(ce.name)
             ),
-            .init(
+            .named(
                 name: ce.name,
                 value: try decodeCaseObject(
                     caseElement: ce,
@@ -269,7 +269,7 @@ private struct EncodeFuncGen {
 
             expr = try generator.converter(for: value.interfaceType).callEncodeField(entity: expr)
 
-            fields.append(.init(
+            fields.append(.named(
                 name: value.codableLabel,
                 value: expr
             ))
@@ -292,7 +292,7 @@ private struct EncodeFuncGen {
         let innerObject = try encodeCaseValue(element: element)
 
         let outerObject = TSObjectExpr([
-            .init(name: element.name, value: innerObject)
+            .named(name: element.name, value: innerObject)
         ])
 
         code.append(TSReturnStmt(outerObject))

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -58,7 +58,7 @@ struct StructConverter: TypeConverter {
                 .callDecodeField(json: expr)
 
             fields.append(
-                .init(
+                .named(
                     name: field.name,
                     value: expr
                 )
@@ -96,7 +96,7 @@ struct StructConverter: TypeConverter {
                 .callEncodeField(entity: expr)
 
             fields.append(
-                .init(
+                .named(
                     name: field.name,
                     value: expr
                 )


### PR DESCRIPTION
TypeScriptASTの更新に追従します。
単純な`TSObjectExpr.Field` がstructからenumに変化したため、その`.init` の置き換えです