### PR TITLE
RawRepresentable対応

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "17b0aa596455d76e1e73b3a9c07907b276e791a7",
-        "version" : "1.2.0"
+        "revision" : "509c3a20d5f8fe7584d4e9d67acc80690ff2fba0",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.1"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.2.0")
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.3.0")
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -29,10 +29,6 @@ public final class CodeGenerator {
         )
     }
 
-    public func converter(for decl: any TypeDecl) throws -> any TypeConverter {
-        return try converter(for: decl.declaredInterfaceType)
-    }
-
     private func implConverter(for type: any SType) throws -> any TypeConverter {
         return try typeConverterProvider.provide(generator: self, type: type)
     }

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -19,6 +19,10 @@ struct GeneratorProxyConverter: TypeConverter {
         return try impl.fieldType(for: target)
     }
 
+    func phantomType(for target: GenerationTarget, name: String) throws -> TSType {
+        return try impl.phantomType(for: target, name: name)
+    }
+
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
         return try impl.typeDecl(for: target)
     }

--- a/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
@@ -24,6 +24,14 @@ struct OptionalConverter: TypeConverter {
         )
     }
 
+    func phantomType(for target: GenerationTarget, name: String) throws -> any TSType {
+        let wrapped = try self.wrapped(limit: nil)
+        return TSUnionType([
+            try wrapped.phantomType(for: target, name: name),
+            TSIdentType.null
+        ])
+    }
+
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
         throw MessageError("Unsupported type: \(swiftType)")
     }

--- a/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
@@ -1,0 +1,58 @@
+import SwiftTypeReader
+import TypeScriptAST
+
+struct RawRepresentableConverter: TypeConverter {
+    var generator: CodeGenerator
+    var swiftType: any SType
+    var rawValueType: any TypeConverter
+
+    func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
+        switch target {
+        case .entity: break
+        case .json:
+            guard try rawValueType.hasJSONType() else { return nil }
+        }
+
+        let name = try self.name(for: target)
+        let type = try rawValueType.phantomType(for: target, name: name)
+
+        return TSTypeDecl(
+            modifiers: [.export],
+            name: name,
+            genericParams: try genericParams().map { try $0.name(for: target) },
+            type: type
+        )
+    }
+
+    func hasDecode() throws -> Bool {
+        return try rawValueType.hasJSONType()
+    }
+
+    func decodeDecl() throws -> TSFunctionDecl? {
+        guard let decl = try decodeSignature() else { return nil }
+
+        var expr = try rawValueType.callDecode(json: TSIdentExpr("json"))
+        expr = TSAsExpr(expr, try self.type(for: .entity))
+        decl.body.elements.append(
+            TSReturnStmt(expr)
+        )
+
+        return decl
+    }
+
+    func hasEncode() throws -> Bool {
+        return try rawValueType.hasJSONType()
+    }
+
+    func encodeDecl() throws -> TSFunctionDecl? {
+        guard let decl = try encodeSignature() else { return nil }
+
+        var expr = try rawValueType.callEncode(entity: TSIdentExpr("entity"))
+        expr = TSAsExpr(expr, try self.type(for: .json))
+        decl.body.elements.append(
+            TSReturnStmt(expr)
+        )
+
+        return decl
+    }
+}

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
@@ -8,6 +8,7 @@ public protocol TypeConverter {
     func hasJSONType() throws -> Bool
     func type(for target: GenerationTarget) throws -> any TSType
     func fieldType(for target: GenerationTarget) throws -> (type: any TSType, isOptional: Bool)
+    func phantomType(for target: GenerationTarget, name: String) throws -> any TSType
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl?
     func hasDecode() throws -> Bool
     func decodeName() throws -> String
@@ -49,9 +50,9 @@ extension TypeConverter {
         return try `default`.fieldType(for: target)
     }
 
-//    public func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
-//        return try `default`.typeDecl(for: target)
-//    }
+    public func phantomType(for target: GenerationTarget, name: String) throws -> any TSType {
+        return try `default`.phantomType(for: target, name: name)
+    }
 
     public func decodeName() throws -> String {
         return try `default`.decodeName()
@@ -107,7 +108,7 @@ extension TypeConverter {
             return []
         }
         return try genericContext.genericParams.items.map { (param) in
-            try generator.converter(for: param)
+            try generator.converter(for: param.declaredInterfaceType)
         }
     }
 
@@ -127,6 +128,7 @@ extension TypeConverter {
             try typeDecl.walk { (type) in
                 let converter = try generator.converter(for: type.declaredInterfaceType)
                 decls += try converter.ownDecls().decls
+                return true
             }
         }
 

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
@@ -33,6 +33,14 @@ public struct TypeConverterProvider {
         } else if let type = type.asEnum {
             return EnumConverter(generator: generator, enum: type)
         } else if let type = type.asStruct {
+            if let raw = type.decl.isRawRepresentable() {
+                return RawRepresentableConverter(
+                    generator: generator,
+                    swiftType: type,
+                    rawValueType: try generator.converter(for: raw)
+                )
+            }
+
             return StructConverter(generator: generator, struct: type)
         } else if let type = type.asGenericParam {
             return GenericParamConverter(generator: generator, param: type)

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -101,4 +101,31 @@ export function S_encode(entity: S): S_JSON {
 """]
         )
     }
+
+    func testAsOperatorIdentityEncode() throws {
+        try assertGenerate(
+            source: """
+enum E {
+    case a(Int)
+}
+
+struct S {
+    var a: E
+    var b: Date
+}
+""",
+            typeMap: dateTypeMap(),
+            expecteds: ["""
+export function S_encode(entity: S): S_JSON {
+    return {
+        a: entity.a as E_JSON,
+        b: Date_encode(entity.b)
+    };
+}
+"""
+            ]
+        )
+
+
+    }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -1,0 +1,345 @@
+import XCTest
+import CodableToTypeScript
+
+final class GenerateRawRepresentableTests: GenerateTestCaseBase {
+    func dateTypeMap() -> TypeMap {
+        var typeMap = TypeMap()
+        typeMap.table["Date"] = .init(name: "Date", decode: "Date_decode", encode: "Date_encode")
+        return typeMap
+    }
+
+    func testStoredProperty() throws {
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: String
+}
+""",
+            expecteds: ["""
+export type S = string & {
+    S: never;
+}
+"""]
+        )
+
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: String
+}
+
+struct K {
+    var a: S
+}
+""",
+            expecteds: ["""
+export type K = {
+    a: S;
+}
+"""],
+            unexpecteds: []
+        )
+    }
+
+    func testComputedProperty() throws {
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: String { "s" }
+}
+""",
+            expecteds: ["""
+export type S = string & {
+    S: never;
+}
+"""]
+        )
+    }
+
+    func testOptional() throws {
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: String?
+}
+""",
+            expecteds: ["""
+export type S = string & {
+    S: never;
+} | null;
+"""]
+        )
+    }
+
+    func testArray() throws {
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: [String]
+}
+""",
+            expecteds: ["""
+export type S = string[] & {
+    S: never;
+}
+"""]
+        )
+    }
+
+    func testStruct() throws {
+        try assertGenerate(
+            source: """
+struct K {
+    var a: Int
+}
+
+struct S: RawRepresentable {
+    var rawValue: K
+}
+""",
+            expecteds: ["""
+export type S = K & {
+    S: never;
+};
+"""],
+            unexpecteds: ["""
+export type S_JSON
+""", """
+export function S_decode
+"""
+                         ]
+        )
+    }
+
+    func testEnum() throws {
+        try assertGenerate(
+            source: """
+enum E {
+    case a(Int)
+}
+
+struct S: RawRepresentable {
+    var rawValue: E
+}
+""",
+            expecteds: ["""
+export type S = E & {
+    S: never;
+};
+""", """
+export type S_JSON = E_JSON & {
+    S_JSON: never;
+};
+""", """
+export function S_decode(json: S_JSON): S {
+    return E_decode(json) as S;
+}
+""", """
+export function S_encode(entity: S): S_JSON {
+    return entity as E_JSON as S_JSON;
+}
+"""
+                       ]
+        )
+    }
+
+    func testEncodeStruct() throws {
+        try assertGenerate(
+            source: """
+struct K {
+    var a: Date
+}
+
+struct S: RawRepresentable {
+    var rawValue: K
+}
+""",
+            typeMap: dateTypeMap(),
+            expecteds: ["""
+export type S = K & {
+    S: never;
+};
+""", """
+export type S_JSON = K_JSON & {
+    S_JSON: never;
+};
+""", """
+export function S_decode(json: S_JSON): S {
+    return K_decode(json) as S;
+}
+""", """
+export function S_encode(entity: S): S_JSON {
+    return K_encode(entity) as S_JSON;
+}
+"""
+                       ]
+        )
+    }
+
+    func testMap() throws {
+        try assertGenerate(
+            source: """
+struct S: RawRepresentable {
+    var rawValue: Date
+}
+""",
+            typeMap: dateTypeMap(),
+            expecteds: ["""
+export type S = Date & {
+    S: never;
+};
+""", """
+export type S_JSON = Date_JSON & {
+    S_JSON: never;
+};
+""", """
+export function S_decode(json: S_JSON): S {
+    return Date_decode(json) as S;
+}
+""", """
+export function S_encode(entity: S): S_JSON {
+    return Date_encode(entity) as S_JSON;
+}
+"""
+                       ]
+        )
+    }
+
+    func testBoundGeneric() throws {
+        try assertGenerate(
+            source: """
+struct K<T> {
+    var a: T
+}
+
+struct S: RawRepresentable {
+    var rawValue: K<Int>
+}
+""",
+            expecteds: ["""
+export type S = K<number> & {
+    S: never;
+};
+""", """
+export type S_JSON = K_JSON<number> & {
+    S_JSON: never;
+};
+""", """
+export function S_decode(json: S_JSON): S {
+    return K_decode(json, identity) as S;
+}
+""", """
+export function S_encode(entity: S): S_JSON {
+    return K_encode(entity, identity) as S_JSON;
+}
+"""
+                       ]
+        )
+    }
+
+    func testMapGeneric() throws {
+        try assertGenerate(
+            source: """
+struct K<T> {
+    var a: T
+}
+
+struct S<U>: RawRepresentable {
+    var rawValue: K<U>
+}
+""",
+            expecteds: ["""
+export type S<U> = K<U> & {
+    S: never;
+};
+""", """
+export type S_JSON<U_JSON> = K_JSON<U_JSON> & {
+    S_JSON: never;
+};
+""", """
+export function S_decode<U, U_JSON>(json: S_JSON<U_JSON>, U_decode: (json: U_JSON) => U): S<U> {
+    return K_decode(json, U_decode) as S<U>;
+}
+""", """
+export function S_encode<U, U_JSON>(entity: S<U>, U_encode: (entity: U) => U_JSON): S_JSON<U_JSON> {
+    return K_encode(entity, U_encode) as S_JSON<U_JSON>;
+}
+"""
+                       ]
+        )
+    }
+
+    func testGenericParam() throws {
+        try assertGenerate(
+            source: """
+struct S<T>: RawRepresentable {
+    var rawValue: T
+}
+""",
+        expecteds: ["""
+export type S<T> = T & {
+    S: never;
+};
+""", """
+export type S_JSON<T_JSON> = T_JSON & {
+    S_JSON: never;
+};
+""", """
+export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
+    return T_decode(json) as S<T>;
+}
+""", """
+export function S_encode<T, T_JSON>(entity: S<T>, T_encode: (entity: T) => T_JSON): S_JSON<T_JSON> {
+    return T_encode(entity) as S_JSON<T_JSON>;
+}
+"""
+                   ]
+        )
+    }
+
+    func testNestedID() throws {
+        try assertGenerate(
+            source: """
+struct User {
+    struct ID {
+        var rawValue: String
+    }
+
+    var id: ID
+    var date: Date
+}
+""",
+            typeMap: dateTypeMap(),
+            expecteds: ["""
+export type User_ID = string & {
+    User_ID: never;
+};
+""", """
+export type User = {
+    id: User_ID;
+    date: Date;
+};
+""", """
+export type User_JSON = {
+    id: User_ID;
+    date: Date_JSON;
+};
+""", """
+export function User_decode(json: User_JSON): User {
+    return {
+        id: json.id,
+        date: Date_decode(json.date)
+    };
+}
+""", """
+export function User_encode(entity: User): User_JSON {
+    return {
+        id: entity.id,
+        date: Date_encode(entity.date)
+    };
+}
+"""
+                       ]
+        )
+    }
+}

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -10,7 +10,7 @@ class GenerateTestCaseBase: XCTestCase {
         case all
     }
     // debug
-    var prints: Prints { .one }
+    var prints: Prints { .none }
 
     func assertGenerate(
         context: Context? = nil,


### PR DESCRIPTION
#40 の対応

Swift側の型情報をなるべくTypeScriptで再現するため、phantom typeの生成を導入した。

```swift
// 入力ソース
struct ID {
  var rawValue: String
}
```

```ts
// 生成コード
type ID = string & { ID: never };
```

判定は `rawValue` プロパティを見ているだけのガバガバ実装。