### PR TITLE
Make json name predictable of custom mapped type

### DIFF
--- a/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
@@ -21,6 +21,9 @@ public struct TypeMapConverter: TypeConverter {
         case .entity:
             return entry.name
         case .json:
+            if let jsonName = entry.jsonType {
+                return jsonName
+            }
             return try `default`.name(for: .json)
         }
     }

--- a/Sources/CodableToTypeScript/Value/TypeMap.swift
+++ b/Sources/CodableToTypeScript/Value/TypeMap.swift
@@ -4,15 +4,18 @@ public struct TypeMap {
     public struct Entry {
         public init(
             name: String,
+            jsonType: String? = nil,
             decode: String? = nil,
             encode: String? = nil
         ) {
             self.name = name
+            self.jsonType = jsonType
             self.decode = decode
             self.encode = encode
         }
 
         public var name: String
+        public var jsonType: String?
         public var decode: String?
         public var encode: String?
     }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -71,7 +71,7 @@ class GenerateTestCaseBase: XCTestCase {
             for expected in expecteds {
                 if !actual.contains(expected) {
                     XCTFail(
-                        "No expected text: \(expected)",
+                        "No expected text: \(expected). actual: \(actual)",
                         file: file, line: line
                     )
                 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -71,7 +71,7 @@ class GenerateTestCaseBase: XCTestCase {
             for expected in expecteds {
                 if !actual.contains(expected) {
                     XCTFail(
-                        "No expected text: \(expected). actual: \(actual)",
+                        "No expected text: \(expected)",
                         file: file, line: line
                     )
                 }


### PR DESCRIPTION
## 僕の理解

現状、カスタムな型マッピングには2つの手法があるように見えます。

1. TypeMapの`table`に要素を追加する
2. 専用のTypeConverterを用意し、TypeConverterProviderの`customProvider`を使って差し込む

1と2の使い分けは非自明ですが、僕は1は変換先となるTSの型が標準ライブラリやDOMなどですでに用意されている型、2はC2TSで生成する型だと思っています。
2のほうが自由度が高いためTypeMapと同等の操作ができますが、記述は多いのでTypeMapでできるならそちらで行うほうが便利に思います。

## 課題

TypeMapによるマッピングの指定には`TypeMap.Entity`を使いますが、これは変換先の型のjson型を指定することができません。
`decode`と`encode`の関数名を指定でき、その関数はどこかで事前に用意する必要があります。
ここでjson型が未定義な場合、その`decode`の引数や`encode`の返り値に正しい型を指定できず、これらの関数を事前に用意することができません。

これを解決するために、`TypeMap.Entity`にjson型を明示的に指定するためのオプションを追加します。

## その他

`TypeMap.Entity`はenumのほうが良いかもと思っています。
今あるテストの`GenerateCusomTypeTests.testCustomDecode`では
`typeMap.table["Date"] = .init(name: "Date", decode: "Date_decode")`
という指定がありますが、これは `Date_decode` の引数となるべき型の名前の予測が困難です。
実際の挙動を辿ると、`TypeMap.Entity`の`decode`プロパティがnilのときは`Date`、そうでないときは`Date_JSON` になるようです。`encode`は考慮されないため、`encode`のみ指定した場合は `Date` になってしまいます。

```swift
enum Entity {
   case identity(name: String)
   case coding(entityType: String, jsonType: String, decode: String?, encode: String?)
}
```

などの見た目になっていたほうが、変換指示に対する実際の操作がわかりやすいかと思いました

## その他2

1と2の使い分けについて、テストケースは例が全て`Date`になっていましたが、1と2のユースケースに沿った型を使ったテストになっているとサンプルになって分かりやすいです。