### PR TITLE
TypeMap.Entryのfactoryメソッドを提供する

### DIFF
--- a/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
@@ -19,12 +19,9 @@ public struct TypeMapConverter: TypeConverter {
     public func name(for target: GenerationTarget) throws -> String {
         switch target {
         case .entity:
-            return entry.name
+            return entry.entityType
         case .json:
-            if let jsonName = entry.jsonType {
-                return jsonName
-            }
-            return try `default`.name(for: .json)
+            return entry.jsonType
         }
     }
 

--- a/Sources/CodableToTypeScript/Value/TypeMap.swift
+++ b/Sources/CodableToTypeScript/Value/TypeMap.swift
@@ -2,20 +2,29 @@ import SwiftTypeReader
 
 public struct TypeMap {
     public struct Entry {
-        public init(
-            name: String,
-            jsonType: String? = nil,
-            decode: String? = nil,
-            encode: String? = nil
-        ) {
-            self.name = name
-            self.jsonType = jsonType
-            self.decode = decode
-            self.encode = encode
+        public static func identity(name: String) -> Entry {
+            return Entry(
+                entityType: name,
+                jsonType: name
+            )
         }
 
-        public var name: String
-        public var jsonType: String?
+        public static func coding(
+            entityType: String,
+            jsonType: String,
+            decode: String?,
+            encode: String?
+        ) -> Entry {
+            return Entry(
+                entityType: entityType,
+                jsonType: jsonType,
+                decode: decode,
+                encode: encode
+            )
+        }
+
+        public var entityType: String
+        public var jsonType: String
         public var decode: String?
         public var encode: String?
     }
@@ -27,12 +36,12 @@ public struct TypeMap {
     )
 
     public static let defaultTable: [String: Entry] = [
-        "Void": Entry(name: "void"),
-        "Bool": Entry(name: "boolean"),
-        "Int": Entry(name: "number"),
-        "Float": Entry(name: "number"),
-        "Double": Entry(name: "number"),
-        "String": Entry(name: "string")
+        "Void": .identity(name: "void"),
+        "Bool": .identity(name: "boolean"),
+        "Int": .identity(name: "number"),
+        "Float": .identity(name: "number"),
+        "Double": .identity(name: "number"),
+        "String": .identity(name: "string")
     ]
 
     public init(

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -4,7 +4,10 @@ import CodableToTypeScript
 final class GenerateEncodeTests: GenerateTestCaseBase {
     func dateTypeMap() -> TypeMap {
         var typeMap = TypeMap()
-        typeMap.table["Date"] = .init(name: "Date", decode: "Date_decode", encode: "Date_encode")
+        typeMap.table["Date"] = .coding(
+            entityType: "Date", jsonType: "string",
+            decode: "Date_decode", encode: "Date_encode"
+        )
         return typeMap
     }
 
@@ -32,7 +35,7 @@ export type E_JSON = {
     a: {};
 } | {
     b: {
-        _0: Date_JSON;
+        _0: string;
     };
 };
 """, """
@@ -82,17 +85,17 @@ export type S = {
 };
 """, """
 export type S_JSON = {
-    a: Date_JSON;
-    b?: Date_JSON;
-    c?: Date_JSON | null;
-    d: Date_JSON[];
+    a: string;
+    b?: string;
+    c?: string | null;
+    d: string[];
 };
 """, """
 export function S_encode(entity: S): S_JSON {
     return {
         a: Date_encode(entity.a),
         b: OptionalField_encode(entity.b, Date_encode),
-        c: OptionalField_encode(entity.c, (entity: Date | null): Date_JSON | null => {
+        c: OptionalField_encode(entity.c, (entity: Date | null): string | null => {
             return Optional_encode(entity, Date_encode);
         }),
         d: Array_encode(entity.d, Date_encode)

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
@@ -213,7 +213,7 @@ struct S {
                 if let ident = repr.asIdent,
                    ident.elements.last?.name == "D"
                 {
-                    return TypeMap.Entry(name: "string")
+                    return .identity(name: "string")
                 }
 
                 return nil

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
@@ -6,10 +6,10 @@ final class GenerateImportTests: GenerateTestCaseBase {
         var typeMap = TypeMap.default
 
         typeMap.table.merge([
-            "A": .init(name: "A"),
-            "B": .init(name: "B"),
-            "C": .init(name: "C"),
-            "Y": .init(name: "Y")
+            "A": .identity(name: "A"),
+            "B": .identity(name: "B"),
+            "C": .identity(name: "C"),
+            "Y": .identity(name: "Y")
         ], uniquingKeysWith: { $1 })
 
         try assertGenerate(

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
@@ -9,7 +9,7 @@ final class GenerateNestedTests: GenerateTestCaseBase {
             if let ident = repr.asIdent,
                ident.elements.last?.name == "ID"
             {
-                return .init(name: "string")
+                return .identity(name: "string")
             }
 
             return nil

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -4,7 +4,10 @@ import CodableToTypeScript
 final class GenerateRawRepresentableTests: GenerateTestCaseBase {
     func dateTypeMap() -> TypeMap {
         var typeMap = TypeMap()
-        typeMap.table["Date"] = .init(name: "Date", decode: "Date_decode", encode: "Date_encode")
+        typeMap.table["Date"] = .coding(
+            entityType: "Date", jsonType: "string",
+            decode: "Date_decode", encode: "Date_encode"
+        )
         return typeMap
     }
 
@@ -221,7 +224,7 @@ export type S = Date & {
     S: never;
 };
 """, """
-export type S_JSON = Date_JSON;
+export type S_JSON = string;
 """, """
 export function S_decode(json: S_JSON): S {
     return Date_decode(json) as S;
@@ -352,7 +355,7 @@ export type User = {
 """, """
 export type User_JSON = {
     id: User_ID_JSON;
-    date: Date_JSON;
+    date: string;
 };
 """, """
 export function User_decode(json: User_JSON): User {


### PR DESCRIPTION
ユーザーは `.identity(...)` か `.coding(...)` を使って構築します。
`coding` においては `jsonType` は必須に変わりました。
自動で用意される `Foo_JSON` 型が自明でなくてあまり嬉しくないため。

Dateのテストケースは、 `jsonType` として `string` を使うように書き換えました。

`enum` での実装も検討しました。
https://github.com/omochi/CodableToTypeScript/pull/47

associated valueを抽出するところで、`_` を並べないといけなくて、
associated valueが増えたら全箇所修正が必要なところがしっくり来ないのでやめました。

computed propertyを定義しない場合は、
利用側のTypeMapConverterで直接分岐する場合、
同じ分岐を重複して出てしまうのが微妙でした。
