### PR TITLE
アサーションを便利にする

### DIFF
--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -48,6 +48,10 @@ export function E_decode(json: E_JSON): E {
     }
 }
 """
+            ],
+            unexpecteds: ["""
+export function E_decode
+"""
             ]
         )
     }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -48,10 +48,6 @@ export function E_decode(json: E_JSON): E {
     }
 }
 """
-            ],
-            unexpecteds: ["""
-export function E_decode
-"""
             ]
         )
     }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -3,6 +3,47 @@ import SwiftTypeReader
 import CodableToTypeScript
 import TypeScriptAST
 
+struct AssertGenerateResult {
+    var generated: String
+    var failureExpecteds: [String] = []
+    var failureUnexpecteds: [String] = []
+    var file: StaticString
+    var line: UInt
+
+    func assert() {
+        if failureExpecteds.isEmpty,
+           failureUnexpecteds.isEmpty
+        {
+            return
+        }
+
+        var strs: [String] = []
+        if !failureExpecteds.isEmpty {
+            let heads = failureExpecteds.map { head($0).debugDescription }
+            strs.append("No expected texts: " + heads.joined(separator: ", "))
+        }
+
+        if !failureUnexpecteds.isEmpty {
+            let heads = failureUnexpecteds.map { head($0).debugDescription }
+            strs.append("Unexpected texts: " + heads.joined(separator: ", "))
+        }
+
+        strs.append("Generated:\n" + generated)
+
+        let message = strs.joined(separator: "; ")
+        XCTFail(message, file: file, line: line)
+    }
+
+    func head(_ string: String) -> String {
+        let lines = string.split(whereSeparator: { $0.isNewline })
+        guard var head = lines.first else { return "" }
+        if lines.count >= 2 {
+            head += "..."
+        }
+        return String(head)
+    }
+}
+
 class GenerateTestCaseBase: XCTestCase {
     enum Prints {
         case none
@@ -68,22 +109,21 @@ class GenerateTestCaseBase: XCTestCase {
 
             let actual = code.print()
 
+            var result = AssertGenerateResult(generated: actual, file: file, line: line)
+
             for expected in expecteds {
                 if !actual.contains(expected) {
-                    XCTFail(
-                        "No expected text: \(expected)",
-                        file: file, line: line
-                    )
+                    result.failureExpecteds.append(expected)
                 }
             }
+
             for unexpected in unexpecteds {
                 if actual.contains(unexpected) {
-                    XCTFail(
-                        "Unexpected text: \(unexpected)",
-                        file: file, line: line
-                    )
+                    result.failureUnexpecteds.append(unexpected)
                 }
             }
+
+            result.assert()
         }
     }
 }


### PR DESCRIPTION
#44 で現状の課題が指摘されたので改善する。

expectedsとunexpectedsをまとめて一つのXCTestのアサーションとした上で、
なにか一つでも問題があれば、生成された全文を出力する、という挙動にした。

以下はアサートされた時のXcodeのスクショ。

<img width="1171" alt="スクリーンショット 2022-12-06 18 49 47" src="https://user-images.githubusercontent.com/312792/205880057-6ef994d8-23a2-4e49-a2b4-483a47e787d6.png">

その時のコンソール出力。

<img width="1183" alt="スクリーンショット 2022-12-06 18 50 02" src="https://user-images.githubusercontent.com/312792/205880119-1ed0aede-3436-4efe-946b-a33ae9bae764.png">
