### PR TITLE
ジェネリックな型のデコーダの呼び出しが不要な場合にカットする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "be01de25a21002d3d42532bfc5069a2b994a90a0",
-        "version" : "2.1.2"
+        "revision" : "1625fa6a7f021acc0b1eb54cd4f24ea9838523cf",
+        "version" : "2.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.1.2"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.2.0"),
         .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.3.0")
     ],
     targets: [

--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -61,17 +61,17 @@ public final class CodeGenerator {
         }
     }
 
-    internal struct HasEncodeRequest: Request {
+    internal struct EncodePresenceRequest: Request {
         var token: RequestToken
         @AnyTypeStorage var type: any SType
 
-        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+        func evaluate(on evaluator: RequestEvaluator) throws -> CodecPresence {
             do {
                 let converter = try token.generator.implConverter(for: type)
-                return try converter.hasEncode()
+                return try converter.encodePresence()
             } catch {
                 switch error {
-                case is CycleRequestError: return true
+                case is CycleRequestError: return .required
                 default: throw error
                 }
             }

--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -44,17 +44,17 @@ public final class CodeGenerator {
         }
     }
 
-    internal struct HasDecodeRequest: Request {
+    internal struct DecodePresenceRequest: Request {
         var token: RequestToken
         @AnyTypeStorage var type: any SType
 
-        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+        func evaluate(on evaluator: RequestEvaluator) throws -> CodecPresence {
             do {
                 let converter = try token.generator.implConverter(for: type)
-                return try converter.hasDecode()
+                return try converter.decodePresence()
             } catch {
                 switch error {
-                case is CycleRequestError: return true
+                case is CycleRequestError: return .required
                 default: throw error
                 }
             }

--- a/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
@@ -39,8 +39,8 @@ struct ArrayConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasEncode() throws -> Bool {
-        return try element().hasEncode()
+    func encodePresence() throws -> CodecPresence {
+        return try element().encodePresence()
     }
 
     func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
@@ -20,8 +20,8 @@ struct ArrayConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasDecode() throws -> Bool {
-        return try element().hasDecode()
+    func decodePresence() throws -> CodecPresence {
+        return try element().decodePresence()
     }
 
     func decodeName() throws -> String? {

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -220,6 +220,18 @@ public struct DefaultTypeConverter {
         )
     }
 
+    public func hasEncode() throws -> Bool {
+        switch try self.converter().encodePresence() {
+        case .identity: return false
+        case .required: return true
+        case .conditional:
+            let args = try swiftType.genericArgs.map {
+                try self.generator.converter(for: $0)
+            }
+            return try args.contains { try $0.hasEncode() }
+        }
+    }
+
     public func encodeName() throws -> String {
         let converter = try self.converter()
         guard try converter.hasEncode() else {

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -3,24 +3,27 @@ import TypeScriptAST
 
 /*
  It provides default impls of TypeConverter.
+
+ Don't call other method from own methods.
+ Call original methods via `converter()` object.
  */
 public struct DefaultTypeConverter {
     public init(generator: CodeGenerator, type: any SType) {
         self.generator = generator
-        self.type = type
+        self.swiftType = type
     }
 
     private var generator: CodeGenerator
-    public var type: any SType
+    public var swiftType: any SType
 
     private func converter() throws -> any TypeConverter {
-        return try generator.converter(for: type)
+        return try generator.converter(for: swiftType)
     }
 
     public func name(for target: GenerationTarget) throws -> String {
         switch target {
         case .entity:
-            return type.namePath().convert()
+            return swiftType.namePath().convert()
         case .json:
             let converter = try self.converter()
 
@@ -71,6 +74,18 @@ public struct DefaultTypeConverter {
         return TSIntersectionType([body, tag])
     }
 
+    public func hasDecode() throws -> Bool {
+        switch try self.converter().decodePresence() {
+        case .identity: return false
+        case .required: return true
+        case .conditional:
+            let args = try swiftType.genericArgs.map {
+                try self.generator.converter(for: $0)
+            }
+            return try args.contains { try $0.hasDecode() }
+        }
+    }
+
     public func decodeName() throws -> String {
         let converter = try self.converter()
         guard try converter.hasDecode() else {
@@ -107,7 +122,7 @@ public struct DefaultTypeConverter {
             )
         }
 
-        if !type.genericArgs.isEmpty {
+        if !swiftType.genericArgs.isEmpty {
             return try makeClosure()
         }
         return TSIdentExpr(
@@ -116,7 +131,7 @@ public struct DefaultTypeConverter {
     }
 
     public func callDecode(json: any TSExpr) throws -> any TSExpr {
-        return try callDecode(genericArgs: type.genericArgs, json: json)
+        return try callDecode(genericArgs: swiftType.genericArgs, json: json)
     }
 
     public func callDecode(genericArgs: [any SType], json: any TSExpr) throws -> any TSExpr {
@@ -241,7 +256,7 @@ public struct DefaultTypeConverter {
             )
         }
 
-        if !type.genericArgs.isEmpty {
+        if !swiftType.genericArgs.isEmpty {
             return try makeClosure()
         }
         return TSIdentExpr(
@@ -250,7 +265,7 @@ public struct DefaultTypeConverter {
     }
 
     public func callEncode(entity: any TSExpr) throws -> any TSExpr {
-        return try callEncode(genericArgs: type.genericArgs, entity: entity)
+        return try callEncode(genericArgs: swiftType.genericArgs, entity: entity)
     }
 
     public func callEncode(genericArgs: [any SType], entity: any TSExpr) throws -> any TSExpr {

--- a/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
@@ -39,8 +39,8 @@ struct DictionaryConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasEncode() throws -> Bool {
-        return try value().hasEncode()
+    func encodePresence() throws -> CodecPresence {
+        return try value().encodePresence()
     }
 
     func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
@@ -20,8 +20,8 @@ struct DictionaryConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasDecode() throws -> Bool {
-        return try value().hasDecode()
+    func decodePresence() throws -> CodecPresence {
+        return try value().decodePresence()
     }
 
     func decodeName() throws -> String? {

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -118,11 +118,11 @@ struct EnumConverter: TypeConverter {
         return TSObjectType(outerFields)
     }
 
-    func hasDecode() throws -> Bool {
+    func decodePresence() throws -> CodecPresence {
         switch kind {
-        case .never: return false
-        case .string: return false
-        case .normal: return true
+        case .never: return .identity
+        case .string: return .identity
+        case .normal: return .required
         }
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/ErrorTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ErrorTypeConverter.swift
@@ -17,7 +17,7 @@ struct ErrorTypeConverter: TypeConverter {
         throw MessageError("Error type can't be converted: \(swiftType)")
     }
 
-    func hasEncode() throws -> Bool {
+    func encodePresence() throws -> CodecPresence {
         throw MessageError("Error type can't be evaluated: \(swiftType)")
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/ErrorTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ErrorTypeConverter.swift
@@ -9,7 +9,7 @@ struct ErrorTypeConverter: TypeConverter {
         throw MessageError("Error type can't be converted: \(swiftType)")
     }
 
-    func hasDecode() throws -> Bool {
+    func decodePresence() throws -> CodecPresence {
         throw MessageError("Error type can't be evaluated: \(swiftType)")
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -28,8 +28,12 @@ struct GeneratorProxyConverter: TypeConverter {
     }
 
     func hasDecode() throws -> Bool {
+        return try impl.hasDecode()
+    }
+
+    func decodePresence() throws -> CodecPresence {
         return try generator.context.evaluator(
-            CodeGenerator.HasDecodeRequest(token: generator.requestToken, type: swiftType)
+            CodeGenerator.DecodePresenceRequest(token: generator.requestToken, type: swiftType)
         )
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -62,8 +62,12 @@ struct GeneratorProxyConverter: TypeConverter {
     }
 
     func hasEncode() throws -> Bool {
+        return try impl.hasEncode()
+    }
+
+    func encodePresence() throws -> CodecPresence {
         return try generator.context.evaluator(
-            CodeGenerator.HasEncodeRequest(token: generator.requestToken, type: swiftType)
+            CodeGenerator.EncodePresenceRequest(token: generator.requestToken, type: swiftType)
         )
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/GenericParamConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GenericParamConverter.swift
@@ -14,6 +14,10 @@ struct GenericParamConverter: TypeConverter {
         return true
     }
 
+    func decodePresence() throws -> CodecPresence {
+        return .conditional
+    }
+
     func decodeDecl() throws -> TSFunctionDecl? {
         throw MessageError("Unsupported type: \(swiftType)")
     }

--- a/Sources/CodableToTypeScript/TypeConverter/GenericParamConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GenericParamConverter.swift
@@ -26,6 +26,10 @@ struct GenericParamConverter: TypeConverter {
         return true
     }
 
+    func encodePresence() throws -> CodecPresence {
+        return .conditional
+    }
+
     func encodeDecl() throws -> TSFunctionDecl? {
         throw MessageError("Unsupported type: \(swiftType)")
     }

--- a/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
@@ -36,8 +36,8 @@ struct OptionalConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasDecode() throws -> Bool {
-        return try wrapped(limit: nil).hasDecode()
+    func decodePresence() throws -> CodecPresence {
+        return try wrapped(limit: nil).decodePresence()
     }
 
     func decodeName() throws -> String? {

--- a/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
@@ -65,8 +65,8 @@ struct OptionalConverter: TypeConverter {
         throw MessageError("Unsupported type: \(swiftType)")
     }
 
-    func hasEncode() throws -> Bool {
-        return try wrapped(limit: nil).hasEncode()
+    func encodePresence() throws -> CodecPresence {
+        return try wrapped(limit: nil).encodePresence()
     }
 
     func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
@@ -2,6 +2,19 @@ import SwiftTypeReader
 import TypeScriptAST
 
 struct RawRepresentableConverter: TypeConverter {
+    init(
+        generator: CodeGenerator,
+        swiftType: any SType,
+        rawValueType raw: any SType
+    ) throws {
+        let map = swiftType.contextSubstitutionMap()
+        let raw = raw.subst(map: map)
+
+        self.generator = generator
+        self.swiftType = swiftType
+        self.rawValueType = try generator.converter(for: raw)
+    }
+
     var generator: CodeGenerator
     var swiftType: any SType
     var rawValueType: any TypeConverter

--- a/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
@@ -44,8 +44,8 @@ struct RawRepresentableConverter: TypeConverter {
         return decl
     }
 
-    func hasEncode() throws -> Bool {
-        return try rawValueType.hasEncode()
+    func encodePresence() throws -> CodecPresence {
+        return try rawValueType.encodePresence()
     }
 
     func encodeDecl() throws -> TSFunctionDecl? {

--- a/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
@@ -28,8 +28,8 @@ struct RawRepresentableConverter: TypeConverter {
         }
     }
 
-    func hasDecode() throws -> Bool {
-        return true
+    func decodePresence() throws -> CodecPresence {
+        return .required
     }
 
     func decodeDecl() throws -> TSFunctionDecl? {

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -84,13 +84,25 @@ struct StructConverter: TypeConverter {
         return decl
     }
 
-    func hasEncode() throws -> Bool {
-        for field in `struct`.decl.storedProperties {
-            if try generator.converter(for: field.interfaceType).hasEncode() {
-                return true
+    func encodePresence() throws -> CodecPresence {
+        let map = `struct`.contextSubstitutionMap()
+
+        let fields = try `struct`.decl.storedProperties.map {
+            try generator.converter(for: $0.interfaceType.subst(map: map))
+        }
+
+        var result: CodecPresence = .identity
+
+        for field in fields {
+            switch try field.encodePresence() {
+            case .identity: break
+            case .required: return .required
+            case .conditional:
+                result = .conditional
             }
         }
-        return false
+
+        return result
     }
 
     func encodeDecl() throws -> TSFunctionDecl? {

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -35,11 +35,10 @@ struct StructConverter: TypeConverter {
     }
 
     func decodePresence() throws -> CodecPresence {
-        /*
-         FIXME: see contextual type instead of interface type here.
-         */
+        let map = `struct`.contextSubstitutionMap()
+
         let fields = try `struct`.decl.storedProperties.map {
-            try generator.converter(for: $0.interfaceType)
+            try generator.converter(for: $0.interfaceType.subst(map: map))
         }
 
         var result: CodecPresence = .identity
@@ -49,10 +48,7 @@ struct StructConverter: TypeConverter {
             case .identity: break
             case .required: return .required
             case .conditional:
-                /*
-                 FIXME: temporary impl for backward compatiblity.
-                 */
-                result = .required
+                result = .conditional
             }
         }
 

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
@@ -11,6 +11,7 @@ public protocol TypeConverter {
     func phantomType(for target: GenerationTarget, name: String) throws -> any TSType
     func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl?
     func hasDecode() throws -> Bool
+    func decodePresence() throws -> CodecPresence
     func decodeName() throws -> String
     func boundDecode() throws -> any TSExpr
     func callDecode(json: any TSExpr) throws -> any TSExpr
@@ -52,6 +53,10 @@ extension TypeConverter {
 
     public func phantomType(for target: GenerationTarget, name: String) throws -> any TSType {
         return try `default`.phantomType(for: target, name: name)
+    }
+
+    public func hasDecode() throws -> Bool {
+        return try `default`.hasDecode()
     }
 
     public func decodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverter.swift
@@ -19,6 +19,7 @@ public protocol TypeConverter {
     func decodeSignature() throws -> TSFunctionDecl?
     func decodeDecl() throws -> TSFunctionDecl?
     func hasEncode() throws -> Bool
+    func encodePresence() throws -> CodecPresence
     func encodeName() throws -> String
     func boundEncode() throws -> any TSExpr
     func callEncode(entity: any TSExpr) throws -> any TSExpr
@@ -77,6 +78,10 @@ extension TypeConverter {
 
     public func decodeSignature() throws -> TSFunctionDecl? {
         return try `default`.decodeSignature()
+    }
+
+    public func hasEncode() throws -> Bool {
+        return try `default`.hasEncode()
     }
 
     public func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
@@ -33,11 +33,11 @@ public struct TypeConverterProvider {
         } else if let type = type.asEnum {
             return EnumConverter(generator: generator, enum: type)
         } else if let type = type.asStruct {
-            if let raw = type.decl.rawValueType() {
-                return RawRepresentableConverter(
+            if var raw = type.decl.rawValueType() {
+                return try RawRepresentableConverter(
                     generator: generator,
                     swiftType: type,
-                    rawValueType: try generator.converter(for: raw)
+                    rawValueType: raw
                 )
             }
 

--- a/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
@@ -29,11 +29,11 @@ public struct TypeMapConverter: TypeConverter {
         return nil
     }
 
-    public func hasDecode() throws -> Bool {
+    public func decodePresence() throws -> CodecPresence {
         if let _ = entry.decode {
-            return true
+            return .required
         }
-        return false
+        return .identity
     }
 
     public func decodeName() throws -> String {

--- a/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeMapConverter.swift
@@ -44,11 +44,11 @@ public struct TypeMapConverter: TypeConverter {
         return nil
     }
 
-    public func hasEncode() throws -> Bool {
+    public func encodePresence() throws -> CodecPresence {
         if let _ = entry.encode {
-            return true
+            return .required
         }
-        return false
+        return .identity
     }
 
     public func encodeName() throws -> String {

--- a/Sources/CodableToTypeScript/Value/CodecPresence.swift
+++ b/Sources/CodableToTypeScript/Value/CodecPresence.swift
@@ -1,0 +1,5 @@
+public enum CodecPresence {
+    case identity
+    case conditional
+    case required
+}

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
@@ -22,8 +22,8 @@ final class GenerateCustomTypeConverterTests: GenerateTestCaseBase {
             return nil
         }
 
-        func hasDecode() throws -> Bool {
-            return true
+        func decodePresence() throws -> CodecPresence {
+            return .required
         }
 
         func decodeName() throws -> String {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
@@ -34,8 +34,8 @@ final class GenerateCustomTypeConverterTests: GenerateTestCaseBase {
             return nil
         }
 
-        func hasEncode() throws -> Bool {
-            return true
+        func encodePresence() throws -> CodecPresence {
+            return .required
         }
 
         func encodeName() throws -> String {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -128,7 +128,5 @@ export function S_encode(entity: S): S_JSON {
 """
             ]
         )
-
-
     }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -42,14 +42,14 @@ struct S {
 export type S = {
     a: K<number>;
 };
-""", """
-export type S_JSON = {
-    a: K_JSON<number>;
-};
 """
             ],
             unexpecteds: ["""
+export type S_JSON
+""", """
 export function S_decode
+""", """
+export function S_encode
 """
             ]
         )
@@ -290,18 +290,18 @@ export type S = {
 };
 """, """
 export type S_JSON = {
-    i: K_JSON<number>;
-    a: K_JSON<A>;
+    i: K<number>;
+    a: K<A>;
     b: K_JSON<B_JSON>;
-    c: K_JSON<C>;
+    c: K<C>;
 };
 """, """
 export function S_decode(json: S_JSON): S {
     return {
-        i: json.i as K<number>,
-        a: json.a as K<A>,
+        i: json.i,
+        a: json.a,
         b: K_decode(json.b, B_decode),
-        c: json.c as K<C>
+        c: json.c
     };
 }
 """
@@ -334,16 +334,16 @@ export type S = {
 };
 """, """
 export type S_JSON = {
-    a: K_JSON<number | null>;
-    b: K_JSON<number[]>;
+    a: K<number | null>;
+    b: K<number[]>;
     c: K_JSON<E_JSON | null>;
     d: K_JSON<E_JSON[]>;
 };
 """, """
 export function S_decode(json: S_JSON): S {
     return {
-        a: json.a as K<number | null>,
-        b: json.b as K<number[]>,
+        a: json.a,
+        b: json.b,
         c: K_decode(json.c, (json: E_JSON | null): E | null => {
             return Optional_decode(json, E_decode);
         }),

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -27,7 +27,8 @@ export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSO
         )
     }
 
-    func testParameterTranspile() throws {
+    // TODO: conditional decode
+    func _testParamIdentity() throws {
         try assertGenerate(
             source: """
 struct K<T> {
@@ -46,12 +47,42 @@ export type S = {
 export type S_JSON = {
     a: K_JSON<number>;
 };
+"""
+            ],
+            unexpecteds: ["""
+export function S_decode
+"""
+            ]
+        )
+    }
+
+    func testParamDecode() throws {
+        try assertGenerate(
+            source: """
+enum E { case a }
+
+struct K<T> {
+    var a: T
+}
+
+struct S {
+    var a: K<E>
+}
+""",
+            expecteds: ["""
+export type S = {
+    a: K<E>;
+};
 """, """
 export function S_decode(json: S_JSON): S {
     return {
-        a: K_decode(json.a, identity)
+        a: K_decode(json.a, E_decode)
     };
 }
+""", """
+export type S_JSON = {
+    a: K_JSON<E_JSON>;
+};
 """
             ]
         )

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -27,8 +27,7 @@ export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSO
         )
     }
 
-    // TODO: conditional decode
-    func _testParamIdentity() throws {
+    func testParamIdentity() throws {
         try assertGenerate(
             source: """
 struct K<T> {
@@ -74,15 +73,15 @@ export type S = {
     a: K<E>;
 };
 """, """
+export type S_JSON = {
+    a: K_JSON<E_JSON>;
+};
+""", """
 export function S_decode(json: S_JSON): S {
     return {
         a: K_decode(json.a, E_decode)
     };
 }
-""", """
-export type S_JSON = {
-    a: K_JSON<E_JSON>;
-};
 """
             ]
         )
@@ -299,10 +298,10 @@ export type S_JSON = {
 """, """
 export function S_decode(json: S_JSON): S {
     return {
-        i: K_decode(json.i, identity),
-        a: K_decode(json.a, identity),
+        i: json.i as K<number>,
+        a: json.a as K<A>,
         b: K_decode(json.b, B_decode),
-        c: K_decode(json.c, identity)
+        c: json.c as K<C>
     };
 }
 """
@@ -343,8 +342,8 @@ export type S_JSON = {
 """, """
 export function S_decode(json: S_JSON): S {
     return {
-        a: K_decode(json.a, identity),
-        b: K_decode(json.b, identity),
+        a: json.a as K<number | null>,
+        b: json.b as K<number[]>,
         c: K_decode(json.c, (json: E_JSON | null): E | null => {
             return Optional_decode(json, E_decode);
         }),

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -366,7 +366,7 @@ struct S<T>: RawRepresentable {
     var rawValue: T
 }
 """,
-        expecteds: ["""
+            expecteds: ["""
 export type S<T> = T & {
     S: never;
 };
@@ -383,6 +383,35 @@ export function S_encode<T, T_JSON>(entity: S<T>, T_encode: (entity: T) => T_JSO
 """
                    ]
         )
+    }
+
+    func testGenericParamApplyIdentity() throws {
+        try assertGenerate(
+            source: """
+struct S<T>: RawRepresentable {
+    var rawValue: T
+}
+
+struct K {
+    var a: S<Int>
+}
+""",
+            expecteds: ["""
+export type K_JSON = {
+    a: S_JSON<number>;
+}
+""", """
+export function K_decode(json: K_JSON): K {
+    return {
+        a: S_decode(json.a, identity)
+    };
+}
+"""],
+            unexpecteds: ["""
+export function K_encode
+"""]
+        )
+
     }
 
     func testNestedID() throws {
@@ -433,7 +462,10 @@ export function User_encode(entity: User): User_JSON {
     };
 }
 """
-                       ]
+                       ],
+            unexpecteds: ["""
+export function User_ID_encode
+"""]
         )
     }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -292,12 +292,11 @@ export type S_JSON = K_JSON<E_JSON>;
 export function S_decode(json: S_JSON): S {
     return K_decode(json, E_decode) as S;
 }
-""", """
-export function S_encode(entity: S): S_JSON {
-    return K_encode(entity, identity) as S_JSON;
-}
 """
-                       ]
+                       ],
+            unexpecteds: ["""
+export function S_encode
+"""]
         )
     }
 
@@ -317,17 +316,16 @@ export type S = K<number> & {
     S: never;
 };
 """, """
-export type S_JSON = K_JSON<number>;
+export type S_JSON = K<number>;
 """, """
 export function S_decode(json: S_JSON): S {
-    return json as K<number> as S;
-}
-""", """
-export function S_encode(entity: S): S_JSON {
-    return K_encode(entity, identity) as S_JSON;
+    return json as S;
 }
 """
-                       ]
+                       ],
+            unexpecteds: ["""
+export function S_encode
+"""]
         )
     }
 

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -301,8 +301,7 @@ export function S_encode(entity: S): S_JSON {
         )
     }
 
-    // TODO: conditional decode
-    func _testBoundGenericIdentity() throws {
+    func testBoundGenericIdentity() throws {
         try assertGenerate(
             source: """
 struct K<T> {


### PR DESCRIPTION
#37 の対応作業。思ったより難しくてブロッカーがあった。

下記のSwiftコードを考える。

```swift
struct V<T> {
  var a: T
}

enum E { case a }

struct S {
  var v: V<E>
}

struct K {
  var v: V<Int>
}
```

Sのデコードにおいては `v` の型 `V.T` が `E` なので、
`V` をデコードするためには `E_decode` の呼び出しが必要。

一方、Kのデコードにおいては `V.T` が `Int` なので、
`V` のデコードは不要。

このように、ジェネリックな型のデコーダは、
型パラメータによってidentityになり呼び出しが不要な場合がある。

これを判定しようとしたが、
現状 `storedProperty` の `VarDecl` から `interfaceType` しか取得できないため、
`V` の `decodePrecense` の評価において、
`a` の型が `T` にしか見えない。

この `T` をジェネリック引数で置換した、
`Int` や `E` を取得するのは、
substitution map の評価による contextual type の取得が必要で、
SWTR に未実装。

簡易に実装する選択肢も検討できるが、
ジェネリクス処理の基盤になるので、
しっかりと調査＆解析してから正しいsemanticsを実装したい。
上述の解釈も正確性がまだ微妙。