### PR TITLE
TagOf と TagRecord の実装

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "39ae67438746f200bfcfe7e32a459cbff16db7fb",
-        "version" : "1.7.0"
+        "revision" : "dcb8d7ff513ec9a4cd2beea1585cfe623dae4e15",
+        "version" : "1.7.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.3.1"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.7.0")
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.7.1")
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
@@ -64,7 +64,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.identity),
-            genericParams: ["T"],
+            genericParams: [.init("T")],
             params: [.init(name: "json", type: TSIdentType("T"))],
             result: TSIdentType("T"),
             body: TSBlockStmt([
@@ -77,7 +77,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalFieldDecode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "json", type: TSUnionType([TSIdentType("T_JSON"), TSIdentType.undefined])),
                 tDecodeParameter()
@@ -99,7 +99,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalFieldEncode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "entity", type: TSUnionType([TSIdentType("T"), TSIdentType.undefined])),
                 tEncodeParameter()
@@ -165,7 +165,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.arrayDecode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "json", type: TSArrayType(TSIdentType("T_JSON"))),
                 tDecodeParameter()
@@ -188,7 +188,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.arrayEncode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "entity", type: TSArrayType(TSIdentType("T"))),
                 tEncodeParameter()
@@ -211,7 +211,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.dictionaryDecode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "json", type: TSObjectType.dictionary(TSIdentType("T_JSON"))),
                 tDecodeParameter()
@@ -255,7 +255,7 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.dictionaryEncode),
-            genericParams: ["T", "T_JSON"],
+            genericParams: [.init("T"), .init("T_JSON")],
             params: [
                 .init(name: "entity", type: TSObjectType.dictionary(TSIdentType("T"))),
                 tEncodeParameter()
@@ -292,6 +292,25 @@ struct HelperLibraryGenerator {
                 ),
                 TSReturnStmt(TSIdentExpr("json"))
             ])
+        )
+    }
+
+    func tagOfDecl() -> TSTypeDecl {
+        return TSTypeDecl(
+            modifiers: [.export],
+            name: name(.tagOf),
+            genericParams: [.init("Type")],
+            type: TSConditionalType(
+                TSIdentType("Type"),
+                extends: TSObjectType([
+                    .field(
+                        name: "$tag", isOptional: true,
+                        type: TSInferType(name: "TAG")
+                    )
+                ]),
+                true: TSIdentType("TAG"),
+                false: TSIdentType.never
+            )
         )
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -177,12 +177,16 @@ public struct DefaultTypeConverter {
             )
         }
 
-        var decodeGenericParams: [String] = []
+        var decodeGenericParams: [TSTypeParameterNode] = []
         for param in genericParams {
-            decodeGenericParams.append(try param.name(for: .entity))
+            decodeGenericParams.append(
+                .init(try param.name(for: .entity))
+            )
         }
         for param in genericParams {
-            decodeGenericParams.append(try param.name(for: .json))
+            decodeGenericParams.append(
+                .init(try param.name(for: .json))
+            )
         }
 
         var params: [TSFunctionType.Param] = [
@@ -323,12 +327,16 @@ public struct DefaultTypeConverter {
             )
         }
 
-        var encodeGenericParams: [String] = []
+        var encodeGenericParams: [TSTypeParameterNode] = []
         for param in genericParams {
-            encodeGenericParams.append(try param.name(for: .entity))
+            encodeGenericParams.append(
+                .init(try param.name(for: .entity))
+            )
         }
         for param in genericParams {
-            encodeGenericParams.append(try param.name(for: .json))
+            encodeGenericParams.append(
+                .init(try param.name(for: .json))
+            )
         }
 
         var params: [TSFunctionType.Param] = [

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -44,7 +44,9 @@ struct EnumConverter: TypeConverter {
             guard try hasJSONType() else { return nil }
         }
 
-        let genericParams = try self.genericParams().map { try $0.name(for: target) }
+        let genericParams: [TSTypeParameterNode] = try self.genericParams().map {
+            .init(try $0.name(for: target))
+        }
 
         switch kind {
         case .never:

--- a/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/RawRepresentableConverter.swift
@@ -24,7 +24,9 @@ struct RawRepresentableConverter: TypeConverter {
             return TSTypeDecl(
                 modifiers: [.export],
                 name: name,
-                genericParams: try genericParams().map { try $0.name(for: target) },
+                genericParams: try genericParams().map {
+                    .init(try $0.name(for: target))
+                },
                 type: type
             )
         }

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -31,7 +31,9 @@ struct StructConverter: TypeConverter {
         return TSTypeDecl(
             modifiers: [.export],
             name: try name(for: target),
-            genericParams: try genericParams().map { try $0.name(for: target) },
+            genericParams: try genericParams().map {
+                .init(try $0.name(for: target))
+            },
             type: TSObjectType(fields)
         )
     }

--- a/Sources/CodableToTypeScript/TypeConverter/TypeAliasConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeAliasConverter.swift
@@ -19,7 +19,9 @@ struct TypeAliasConverter: TypeConverter {
         return TSTypeDecl(
             modifiers: [.export],
             name: try name(for: target),
-            genericParams: try genericParams().map { try $0.name(for: target) },
+            genericParams: try genericParams().map {
+                .init(try $0.name(for: target))
+            },
             type: try underlying().type(for: target)
         )
     }

--- a/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
+++ b/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
@@ -54,5 +54,22 @@ export function Dictionary_encode<T, T_JSON>(entity: {
     [key: string]: T_JSON;
 }
 """))
+
+        XCTAssertTrue(actual.contains("""
+export type TagOf<Type> = Type extends {
+    $tag?: infer TAG;
+} ? TAG : never;
+"""))
+
+        XCTAssertTrue(actual.contains("""
+export type TagRecord<Name extends string, Args extends any[] = []> = Args["length"] extends 0 ? {
+    $tag?: Name;
+} : {
+    $tag?: Name & {
+        [I in keyof Args]: TagOf<Args[I]>;
+    };
+};
+"""))
+
     }
 }


### PR DESCRIPTION
TSASTのアップグレードを巻き込んだのでスコープを縮める

---

#54 の実装
#53 も同時に解決される

ユーザーの使いやすさのため、 #51 も必要だろう
というか、enumに限らずタグが付く全ての型のinitを提供する必要がある