### PR TITLE
PackageGeneratorの外部参照の扱いをシンプルにする

### DIFF
--- a/Docs/PackageGenerator.md
+++ b/Docs/PackageGenerator.md
@@ -1,0 +1,35 @@
+# PackageGenerator
+
+PackageGeneratorはTypeScriptコードの一括生成器です。
+これに `SwiftTypeReader.Module` を渡す事により、そのモジュールに読み込まれたSwiftの型を、
+一括でTypeScriptに変換し、ライブラリとして利用可能なソースファイルを含んだディレクトリを生成します。
+
+モジュールは複数渡すこともできますが、複数のモジュールに同名の型が含まれる状況には対応していません。
+
+生成されたディレクトリには、共通ライブラリの`common.ts`、型ごとのソースが含まれます。
+例えば読み込んだモジュールに型`struct S`と`enum E`がある場合、`S.ts`と`E.ts`が生成されます。
+状況に応じて、`externals.ts`が生成されます。これについては後述します。
+
+## 外部参照
+
+TypeMapやTypeConverterをカスタムすることによって、外部で定義したTypeScriptコードと連携させる事ができます。
+この際、コード生成は外部のシンボルが全て`externals.ts`に定義されているものとして行われます。
+ここで必要な外部シンボルの一覧と、`externals.ts`の実装は、
+ユーザーが`ExternalReference`型のオブジェクトとして`PackageGenerator`に指定します。
+
+例えばTypeMapを使うことで、Swiftの`Date`型をTypeScriptの`Date`型にトランスパイルさせる事ができます。
+その際に`Date`型のJSON表現と、JSON表現との相互変換関数を指定します。
+そして変換関数として`Date_decode`と`Date_encode`を指定する場合を考えます。
+
+これらの関数は`custom.ts`というファイルに定義され、PackageGeneratorは`swift`ディレクトリにコードを生成するとします。
+
+```
+src/
+├ custom.ts
+└ swift/
+　 ├ common.ts
+　 ├ S.ts
+　 └ externals.ts
+```
+
+いや、やっぱり仕様を変えよう。

--- a/Docs/PackageGenerator.md
+++ b/Docs/PackageGenerator.md
@@ -8,28 +8,9 @@ PackageGeneratorはTypeScriptコードの一括生成器です。
 
 生成されたディレクトリには、共通ライブラリの`common.ts`、型ごとのソースが含まれます。
 例えば読み込んだモジュールに型`struct S`と`enum E`がある場合、`S.ts`と`E.ts`が生成されます。
-状況に応じて、`externals.ts`が生成されます。これについては後述します。
 
 ## 外部参照
 
 TypeMapやTypeConverterをカスタムすることによって、外部で定義したTypeScriptコードと連携させる事ができます。
-この際、コード生成は外部のシンボルが全て`externals.ts`に定義されているものとして行われます。
-ここで必要な外部シンボルの一覧と、`externals.ts`の実装は、
-ユーザーが`ExternalReference`型のオブジェクトとして`PackageGenerator`に指定します。
-
-例えばTypeMapを使うことで、Swiftの`Date`型をTypeScriptの`Date`型にトランスパイルさせる事ができます。
-その際に`Date`型のJSON表現と、JSON表現との相互変換関数を指定します。
-そして変換関数として`Date_decode`と`Date_encode`を指定する場合を考えます。
-
-これらの関数は`custom.ts`というファイルに定義され、PackageGeneratorは`swift`ディレクトリにコードを生成するとします。
-
-```
-src/
-├ custom.ts
-└ swift/
-　 ├ common.ts
-　 ├ S.ts
-　 └ externals.ts
-```
-
-いや、やっぱり仕様を変えよう。
+生成するコードがこれらの外部シンボルを正しく`import`できるように、
+外部シンボルを登録したSymbolTableを渡してください。

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,21 +28,12 @@
       }
     },
     {
-      "identity" : "swiftyrelativepath",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/neoneye/SwiftyRelativePath",
-      "state" : {
-        "revision" : "36c56e0b3269d58ee46ced1eef797ca2bd65a818",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "typescriptast",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "952da439d8a056e0bb96e512585a505afca00469",
-        "version" : "1.8.3"
+        "revision" : "9f0c8cff4d29a487a32b15a2f9912b1483ed2f1d",
+        "version" : "1.8.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.3.1"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.3")
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.4")
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Value/PackageEntry.swift
+++ b/Sources/CodableToTypeScript/Value/PackageEntry.swift
@@ -3,13 +3,13 @@ import TypeScriptAST
 
 public struct PackageEntry {
     public init(
-        file: String,
+        file: URL,
         source: TSSourceFile
     ) {
         self.file = file
         self.source = source
     }
     
-    public var file: String
+    public var file: URL
     public var source: TSSourceFile
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
@@ -43,6 +43,7 @@ struct S {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: ["Date_decode"],
                 code: """
                 export function Date_decode(json: string): Date { throw 0; }
                 """
@@ -87,6 +88,7 @@ struct S {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: ["Date_decode"],
                 code: """
                 export function Date_decode(json: string): Date { throw 0; }
                 """
@@ -136,6 +138,7 @@ struct S {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: ["Date_encode"],
                 code: """
                 export function Date_encode(date: Date): string { throw 0; }
                 """
@@ -178,6 +181,7 @@ struct S {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: ["Date_decode", "Date_encode"],
                 code: """
                 export function Date_decode(json: string): Date { throw 0; }
                 export function Date_encode(date: Date): string { throw 0; }
@@ -233,6 +237,11 @@ struct S {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: [
+                    "Date_decode", "Date_encode",
+                    "Vector2", "Vector2_JSON",
+                    "Vector2_decode", "Vector2_encode"
+                ],
                 code: """
                 export function Date_decode(json: string): Date { throw 0; }
                 export function Date_encode(date: Date): string { throw 0; }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
@@ -29,6 +29,7 @@ struct S<T, U> {
 """,
             typeMap: typeMap,
             externalReference: ExternalReference(
+                symbols: ["A", "B", "C", "Y"],
                 code: """
                 export type A = {};
                 export type B = {};

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTestCaseBase.swift
@@ -23,6 +23,9 @@ class GenerateTestCaseBase: XCTestCase {
 
     func dateTypeExternal() -> ExternalReference {
         return ExternalReference(
+            symbols: [
+                "Date_decode", "Date_encode"
+            ],
             code: """
             export function Date_decode(json: string): Date { throw 0; }
             export function Date_encode(date: Date): string { throw 0; }
@@ -56,9 +59,6 @@ class GenerateTestCaseBase: XCTestCase {
                 typeMap: typeMap
             )
 
-            var externalReference: ExternalReference = externalReference ?? ExternalReference()
-            externalReference.add(entries: typeConverterProvider.typeMap.entries)
-
             let packageTester = PackageBuildTester(
                 context: context,
                 typeConverterProvider: typeConverterProvider,
@@ -73,7 +73,7 @@ class GenerateTestCaseBase: XCTestCase {
             func generate(type: any TypeDecl) throws -> TSSourceFile {
                 let code = try gen.converter(for: type.declaredInterfaceType).source()
                 let imports = try code.buildAutoImportDecls(
-                    from: "test.ts",
+                    from: URL(fileURLWithPath: "test.ts"),
                     symbolTable: SymbolTable(),
                     fileExtension: packageTester.packageGenerator.importFileExtension,
                     defaultFile: ".."

--- a/Tests/CodableToTypeScriptTests/Utils/ExternalReference.swift
+++ b/Tests/CodableToTypeScriptTests/Utils/ExternalReference.swift
@@ -9,10 +9,4 @@ public struct ExternalReference {
 
     public var symbols: Set<String>
     public var code: String
-
-    public mutating func add(entries: [TypeMap.Entry]) {
-        for entry in entries {
-            symbols.formUnion(entry.symbols)
-        }
-    }
 }


### PR DESCRIPTION
外部シンボルはSymbolTableを渡す事で正しくimportされるインターフェースにした