### PR TITLE
生成パスにモジュールディレクトリを含める

### DIFF
--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -44,7 +44,7 @@ public final class PackageGenerator {
                 let tsSource = try codeGenerator.convert(source: source)
 
                 let entry = PackageEntry(
-                    file: path(source.file.replacingPathExtension("ts").relativePath),
+                    file: try tsPath(module: module, file: source.file),
                     source: tsSource
                 )
                 entries.append(entry)
@@ -69,6 +69,17 @@ public final class PackageGenerator {
         }
 
         return entries
+    }
+
+    private func tsPath(module: Module, file: URL) throws -> URL {
+        if file.baseURL == nil {
+            throw MessageError("needs relative path: \(file.path)")
+        }
+
+        return self.path(
+            module.name + "/" +
+            file.replacingPathExtension("ts").relativePath
+        )
     }
 
     private func path(_ name: String) -> URL {

--- a/Tests/CodableToTypeScriptTests/Utils/PackageBuildTester.swift
+++ b/Tests/CodableToTypeScriptTests/Utils/PackageBuildTester.swift
@@ -26,7 +26,7 @@ struct PackageBuildTester {
         let dir = fileManager.temporaryDirectory
             .appendingPathComponent("CodableToTypeScriptTests")
             .appendingPathComponent(makeLaunchName())
-        print("[PackageBuildTester]: \(dir.path)")
+        print("[PackageBuildTester]: launchDir=\(dir.path)")
         launchDirectoryCache = dir
         return dir
     }


### PR DESCRIPTION
元々 SWTR側で `Sources` ディレクトリを指定することで、
`module/path.../file.swift` を読み込ませる事を想定していたが、
これは間違いで、 `Reader` が一つのモジュールに束縛されているので、
実際には `path.../file.swift` がロードされている。

これをトランスパイルする時に、
複数モジュールを変換すると中身が混ざるので、
固定でモジュールディレクトリを切る事にする。