### PR TITLE
Add dark scheme support to editor space

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -12,6 +12,7 @@ function App() {
         height: "3.2rem",
         display: "flex", flexDirection: "row", alignItems: "center",
         justifyContent: "space-between",
+        borderBottom: "1px solid var(--border-color)",
       }}>
         <h3 style={{ margin: "8pt" }}>
           CodableToTypeScript DEMO

--- a/demo/src/Editors.tsx
+++ b/demo/src/Editors.tsx
@@ -3,6 +3,7 @@ import * as monaco from "monaco-editor";
 import { useCallback, useEffect, useState } from "react";
 import { useC2TS } from "./C2TSContext";
 import { Generator } from "./Gen/Generator.gen";
+import { useColorScheme } from "./Utils";
 
 type GeneratorState = {
   isReady: false,
@@ -30,6 +31,7 @@ const useGenerator = (): GeneratorState => {
 export const Editors: React.FC = () => {
   const monaco = useMonaco();
   const { isReady, generator } = useGenerator();
+  const theme = useColorScheme() === "light" ? "light" : "vs-dark";
 
   const [swiftEditor, setSwiftEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [tsEditor, setTsEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -58,7 +60,7 @@ export const Editors: React.FC = () => {
           "typescript",
           monaco.Uri.from({ scheme: "file", path: "./common.gen.ts" })
         );
-      } catch (e) { console.error(e) };
+      } catch (e) {console.error(e);}
       updateTSCode();
     }
   }, [isReady, swiftEditor, tsEditor, updateTSCode]);
@@ -76,6 +78,7 @@ export const Editors: React.FC = () => {
           },
         }}
         onChange={updateTSCode}
+        theme={theme}
       />
     </div>
     <div style={{ flex: 1 }}>
@@ -89,6 +92,7 @@ export const Editors: React.FC = () => {
             enabled: false,
           },
         }}
+        theme={theme}
       />
     </div>
   </>

--- a/demo/src/Utils.ts
+++ b/demo/src/Utils.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+const checkColorScheme = (): "dark" | "light" => {
+  if (window.matchMedia) {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return "dark";
+    }
+  }
+  return "light";
+}
+
+export const useColorScheme = (): "dark" | "light" => {
+  const [scheme, setScheme] = useState(checkColorScheme);
+  useEffect(() => {
+    if (window.matchMedia) {
+      const query = window.matchMedia("(prefers-color-scheme: dark)");
+      const callback = () => setScheme(checkColorScheme);
+      query.addEventListener("change", callback);
+      return () => query.removeEventListener("change", callback);
+    }
+  }, []);
+
+  return scheme;
+}

--- a/demo/src/Utils.ts
+++ b/demo/src/Utils.ts
@@ -19,6 +19,5 @@ export const useColorScheme = (): "dark" | "light" => {
       return () => query.removeEventListener("change", callback);
     }
   }, []);
-
   return scheme;
 }

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -57,7 +57,6 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -7,6 +7,7 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --border-color: #444;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -56,10 +57,12 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
+    --border-color: #ddd;
   }
   a:hover {
     color: #747bff;


### PR DESCRIPTION
![スクリーンショット 2023-01-16 12 31 10](https://user-images.githubusercontent.com/19257572/212592807-a8a03469-2060-43e5-a769-0b47c2e0f3a7.png)

demoサイトについて、今までヘッダー部分は地味にダークモード対応していたんですが、エディタ部分はしていませんでした。
この半端な対応のせいで、.wasmファイルの読み込み完了時にダークモードで一瞬黒背景がチラついて目に悪いので、エディタ部分もダークモードに対応するようにしました。