### PR TITLE
Update demo's CodableToTypeScript

### DIFF
--- a/demo/Package.resolved
+++ b/demo/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/sidepelican/CodableToTypeScript.git",
       "state" : {
         "branch" : "wasi",
-        "revision" : "77100a51e3b5e7be803356bb744da714f0bb7b3b"
+        "revision" : "4df44f23c6eaf2f33f57300b5ceb7dd717782cea"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
-        "version" : "1.2.0"
+        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
+        "version" : "1.2.1"
       }
     },
     {


### PR DESCRIPTION
デモに使用されるCodableToTypeScriptのバージョンをあげます。
https://github.com/sidepelican/CodableToTypeScript/tree/wasi を最新にリベースしました