### PR TITLE
return symbols from PackageGenerator

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "fd7961c8cb06954f1934852756f59541742672e9",
-        "version" : "1.8.5"
+        "revision" : "d454923c7deba1fc6a9b04404e2cc5557b34a36c",
+        "version" : "1.8.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.5.0"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.5")
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6")
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -34,7 +34,12 @@ public final class PackageGenerator {
     public var didGenerateEntry: ((SourceFile, PackageEntry) throws -> Void)?
     public var didWrite: ((URL, Data) throws -> Void)?
 
-    public func generate(modules: [Module]) throws -> [PackageEntry] {
+    public struct GenerateResult {
+        public var entries: [PackageEntry]
+        public var symbols: SymbolTable
+    }
+
+    public func generate(modules: [Module]) throws -> GenerateResult {
         var entries: [PackageEntry] = [
             PackageEntry(
                 file: self.path("common.\(typeScriptExtension)"),
@@ -79,7 +84,10 @@ public final class PackageGenerator {
             }
         }
 
-        return entries
+        return GenerateResult(
+            entries: entries,
+            symbols: symbols
+        )
     }
 
     private func tsPath(module: Module, file: URL) throws -> URL {
@@ -89,7 +97,7 @@ public final class PackageGenerator {
 
         return self.path(
             module.name + "/" +
-            file.replacingPathExtension(typeScriptExtension).relativePath
+            URLs.replacingPathExtension(of: file, to: typeScriptExtension).relativePath
         )
     }
 

--- a/Tests/CodableToTypeScriptTests/Utils/PackageBuildTester.swift
+++ b/Tests/CodableToTypeScriptTests/Utils/PackageBuildTester.swift
@@ -97,7 +97,7 @@ struct PackageBuildTester {
     func build(module: Module) throws {
         if isSkipped { return }
         
-        let entries = try packageGenerator.generate(modules: [module])
+        let entries = try packageGenerator.generate(modules: [module]).entries
         try packageGenerator.write(entries: entries)
         try writeExternals()
         try writeTSConfig()


### PR DESCRIPTION
`PackageGenerator` が更新したsymbolsをユーザー側で使いたい事がある