### PR TITLE
Demo application uses root C2TS package

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - run: ci/apt.bash
       - uses: swiftwasm/setup-swiftwasm@v1
         with:
-          swift-version: "wasm-5.7-SNAPSHOT-2023-01-09-a"
+          swift-version: "wasm-5.8.0-RELEASE"
       - run: ci/wabt.bash
       - run: ci/build.bash
       - uses: peaceiris/actions-gh-pages@v3

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftTypeReader
 import TypeScriptAST
 
+#if !os(WASI)
 public final class PackageGenerator {
     public init(
         context: SwiftTypeReader.Context,
@@ -130,3 +131,4 @@ public final class PackageGenerator {
         }
     }
 }
+#endif

--- a/demo/.swift-version
+++ b/demo/.swift-version
@@ -1,1 +1,1 @@
-wasm-5.7-SNAPSHOT-2023-01-09-a
+wasm-5.8.0-RELEASE

--- a/demo/Package.resolved
+++ b/demo/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "codabletotypescript",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sidepelican/CodableToTypeScript.git",
-      "state" : {
-        "branch" : "wasi",
-        "revision" : "4df44f23c6eaf2f33f57300b5ceb7dd717782cea"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
-        "version" : "1.2.1"
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
       }
     },
     {
@@ -30,10 +21,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sidepelican/swift-syntax",
+      "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "branch" : "wasi",
-        "revision" : "24c34287f5567d2aeab360fd8e2de8e68b88492a"
+        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
+        "version" : "508.0.0"
       }
     },
     {
@@ -41,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "wasi",
-        "revision" : "0c56979fc213403b0335e3ff76d1565731712f7e"
+        "revision" : "dca7ae04b1cc71db4fb82ea713982adaa0c0a695",
+        "version" : "2.5.1"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "fd7961c8cb06954f1934852756f59541742672e9",
-        "version" : "1.8.5"
+        "revision" : "c64e4a060a3daa9f8c964699ca4d8210235df20b",
+        "version" : "1.8.7"
       }
     },
     {
@@ -59,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sidepelican/WasmCallableKit.git",
       "state" : {
-        "revision" : "8d0ccfb35e62875fb0578df7ba68828a68e37d77",
-        "version" : "0.3.0"
+        "revision" : "6b551cdaf5d8518848b06bcaf345d1a757496045",
+        "version" : "0.3.2"
       }
     }
   ],

--- a/demo/Package.swift
+++ b/demo/Package.swift
@@ -9,9 +9,8 @@ let package = Package(
         .executable(name: "C2TS", targets: ["C2TS"]),
     ],
     dependencies: [
-//        .package(path: ".."),
-        .package(url: "https://github.com/sidepelican/CodableToTypeScript.git", branch: "wasi"),
-        .package(url: "https://github.com/sidepelican/WasmCallableKit.git", from: "0.3.0"),
+        .package(path: ".."),
+        .package(url: "https://github.com/sidepelican/WasmCallableKit.git", from: "0.3.2"),
     ],
     targets: [
         .executableTarget(

--- a/demo/Sources/C2TS/Generator.swift
+++ b/demo/Sources/C2TS/Generator.swift
@@ -14,7 +14,7 @@ public final class Generator {
     public func tsTypes(swiftSource: String) throws -> String {
         try withExtendedLifetime(SwiftTypeReader.Context()) { context in
             let reader = SwiftTypeReader.Reader(context: context)
-            let swiftSource = try reader.read(source: swiftSource, file: URL(fileURLWithPath: "/Types.swift"))
+            let swiftSource = reader.read(source: swiftSource, file: URL(fileURLWithPath: "/Types.swift"))
 
             let tsSource = try CodeGenerator(context: context)
                 .convert(source: swiftSource)

--- a/demo/src/Gen/common.gen.ts
+++ b/demo/src/Gen/common.gen.ts
@@ -54,14 +54,14 @@ export function Dictionary_encode<T, T_JSON>(entity: Map<string, T>, T_encode: (
     return json;
 }
 
-export type TagOf<Type> = Type extends TagRecord<infer TAG>
+export type TagOf<Type> = [Type] extends [TagRecord<infer TAG>]
     ? TAG
     : null extends Type
-        ? "Optional" & TagOf<Exclude<Type, null>>
+        ? "Optional" & [TagOf<Exclude<Type, null>>]
         : Type extends (infer E)[]
-            ? "Array" & TagOf<E>
+            ? "Array" & [TagOf<E>]
             : Type extends Map<string, infer V>
-                ? "Dictionary" & TagOf<V>
+                ? "Dictionary" & [TagOf<V>]
                 : never
 ;
 


### PR DESCRIPTION
これまでデモアプリケーションは、このリポジトリのC2TSではなくWASI対応した別のC2TSを使用していました。
SwiftSyntax508が正式にリリースされたことでWASIで動くようになったため、デモアプリケーションで専用フォークのC2TSを利用する必要がなくなりました。

各種依存パッケージのSwiftSyntax508対応が完了したため、デモアプリの依存をこのリポジトリ本体のC2TSに置き換えます。