### PR TITLE
Add support for integer rawValue enum

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: swift-actions/setup-swift@v1
         with:
-          swift-version: "5.7"
+          swift-version: "5.8"
       - uses: actions/checkout@v3
       - run: swift package resolve
       - run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "76206f746da09de6386c1acd9a500919d13c5693",
-        "version" : "2.5.0"
+        "branch" : "case_rawvalue",
+        "revision" : "0e5b954c7fb385cc478e77dce57370878e8b476a"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
         "branch" : "case_rawvalue",
-        "revision" : "0e5b954c7fb385cc478e77dce57370878e8b476a"
+        "revision" : "5e7a6fcedd46d645ea171b93d28cbdaa292a2ad8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 
 import PackageDescription
 
 let package = Package(
     name: "CodableToTypeScript",
-    platforms: [.macOS(.v12)],
+    platforms: [.macOS(.v13)],
     products: [
         .library(
             name: "CodableToTypeScript",
@@ -12,7 +12,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.5.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "case_rawvalue"),
         .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6")
     ],
     targets: [
@@ -24,6 +24,9 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftTypeReader", package: "SwiftTypeReader"),
                 .product(name: "TypeScriptAST", package: "TypeScriptAST")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals"),
             ]
         ),
         .testTarget(

--- a/Sources/CodableToTypeScript/Extensions/STypeEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/STypeEx.swift
@@ -39,9 +39,15 @@ extension NominalTypeDecl {
         self.name == name
     }
 
+    public func isStandardLibraryType(_ regex: some RegexComponent) -> Bool {
+        return moduleContext.name == "Swift" &&
+        !self.name.matches(of: regex).isEmpty
+    }
+
     public func rawValueType() -> (any SType)? {
         for type in inheritedTypes {
             if type.isStandardLibraryType("String") { return type }
+            if type.isStandardLibraryType(/U?Int(8|16|32|64)?/) { return type }
         }
 
         if let property = find(name: "rawValue") as? VarDecl {
@@ -128,6 +134,11 @@ extension SType {
     public func isStandardLibraryType(_ name: String) -> Bool {
         guard let self = self.asNominal else { return false }
         return self.nominalTypeDecl.isStandardLibraryType(name)
+    }
+
+    public func isStandardLibraryType(_ regex: some RegexComponent) -> Bool {
+        guard let self = self.asNominal else { return false }
+        return self.nominalTypeDecl.isStandardLibraryType(regex)
     }
 }
 

--- a/Sources/CodableToTypeScript/Extensions/STypeEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/STypeEx.swift
@@ -47,7 +47,7 @@ extension NominalTypeDecl {
     public func rawValueType() -> (any SType)? {
         for type in inheritedTypes {
             if type.isStandardLibraryType("String") { return type }
-            if type.isStandardLibraryType(/U?Int(8|16|32|64)?/) { return type }
+            if type.isStandardLibraryType(/^U?Int(8|16|32|64)?$/) { return type }
         }
 
         if let property = find(name: "rawValue") as? VarDecl {

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -193,7 +193,7 @@ struct EnumConverter: TypeConverter {
     func decodeDecl() throws -> TSFunctionDecl? {
         switch kind {
         case .never, .string:
-            throw MessageError("logical error")
+            return nil
         case .int:
             return try DecodeIntFuncGen(
                 converter: self,
@@ -239,7 +239,7 @@ struct EnumConverter: TypeConverter {
     func encodeDecl() throws -> TSFunctionDecl? {
         switch kind {
         case .never, .string:
-            throw MessageError("logical error")
+            return nil
         case .int:
             return try EncodeIntFuncGen(
                 converter: self,

--- a/Sources/CodableToTypeScript/Value/TypeMap.swift
+++ b/Sources/CodableToTypeScript/Value/TypeMap.swift
@@ -53,9 +53,19 @@ public struct TypeMap {
         "Void": .identity(name: "void"),
         "Bool": .identity(name: "boolean"),
         "Int": .identity(name: "number"),
+        "Int8": .identity(name: "number"),
+        "Int16": .identity(name: "number"),
+        "Int32": .identity(name: "number"),
+        "Int64": .identity(name: "number"),
+        "UInt8": .identity(name: "number"),
+        "UInt16": .identity(name: "number"),
+        "UInt32": .identity(name: "number"),
+        "UInt64": .identity(name: "number"),
         "Float": .identity(name: "number"),
+        "Float32": .identity(name: "number"),
+        "Float64": .identity(name: "number"),
         "Double": .identity(name: "number"),
-        "String": .identity(name: "string")
+        "String": .identity(name: "string"),
     ]
 
     public init(

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -243,6 +243,45 @@ export type E = "a" |
         )
     }
 
+    func testIntRawValueCase() throws {
+        try assertGenerate(
+            source: """
+enum E: Int, Codable, Sendable {
+    case a
+    case b = -100
+    case c
+}
+""",
+            expecteds: ["""
+export type E = "a" | "b" | "c";
+""", """
+export type E_JSON = 0 | -100 | -99;
+""", """
+export function E_decode(json: E_JSON): E {
+    switch (json) {
+    case 0:
+        return "a";
+    case -100:
+        return "b";
+    case -99:
+        return "c";
+    }
+}
+""", """
+export function E_encode(entity: E): E_JSON {
+    switch (entity) {
+    case "a":
+        return 0;
+    case "b":
+        return -100;
+    case "c":
+        return -99;
+    }
+}
+"""]
+        )
+    }
+
     func testAssociatedValueDecode() throws {
         try assertGenerate(
             source: """


### PR DESCRIPTION
RawValueが整数型のenumのエンコード・デコードに対応します。既存ではStringのみサポートされていましたが、それに追加する形です。

TypeScript側での利用時はstringのunionに変換されます。JSON表現ではnumberとなります
詳しくはテストケースを参照してください。