### PR TITLE
Update to version tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "branch" : "case_rawvalue",
-        "revision" : "5e7a6fcedd46d645ea171b93d28cbdaa292a2ad8"
+        "revision" : "8c6c49a70eb3492e11393c16103156a0b9f66e09",
+        "version" : "2.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "case_rawvalue"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6")
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.0"),
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
https://github.com/omochi/CodableToTypeScript/pull/101 において依存がブランチ指定のままだった部分を、さっきリリースしたバージョンに置き換えます