### PR TITLE
Escape variable identifier from TSKeywords

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "8c6c49a70eb3492e11393c16103156a0b9f66e09",
-        "version" : "2.6.0"
+        "branch" : "case_unescape",
+        "revision" : "6c94e34fb7f44ec3645c7c6f0372b103abe80a42"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", branch: "case_unescape"),
         .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6"),
     ],
     targets: [

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -283,7 +283,7 @@ private struct DecodeObjFuncGen {
                         .callDecodeField(json: expr)
 
                     return TSVarDecl(
-                        kind: .const, name: label,
+                        kind: .const, name: TSKeyword.escaped(label),
                         initializer: expr
                     )
                 }
@@ -296,7 +296,7 @@ private struct DecodeObjFuncGen {
             let label = value.codableLabel
             return TSObjectExpr.Field.named(
                 name: label,
-                value: TSIdentExpr(label)
+                value: TSIdentExpr(TSKeyword.escaped(label))
             )
         })
     }
@@ -413,7 +413,7 @@ private struct EncodeObjFuncGen {
                         .callEncodeField(entity: expr)
 
                     return TSVarDecl(
-                        kind: .const, name: value.codableLabel,
+                        kind: .const, name: TSKeyword.escaped(value.codableLabel),
                         initializer: expr
                     )
                 }
@@ -425,7 +425,7 @@ private struct EncodeObjFuncGen {
         return TSObjectExpr(element.associatedValues.map { (value) in
             return TSObjectExpr.Field.named(
                 name: value.codableLabel,
-                value: TSIdentExpr(value.codableLabel)
+                value: TSIdentExpr(TSKeyword.escaped(value.codableLabel))
             )
         })
     }

--- a/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/StructConverter.swift
@@ -88,7 +88,7 @@ struct StructConverter: TypeConverter {
                 }
 
                 let def = TSVarDecl(
-                    kind: .const, name: field.name,
+                    kind: .const, name: TSKeyword.escaped(field.name),
                     initializer: expr
                 )
 
@@ -97,7 +97,7 @@ struct StructConverter: TypeConverter {
         }
 
         for field in decl.storedProperties {
-            let expr = TSIdentExpr(field.name)
+            let expr = TSIdentExpr(TSKeyword.escaped(field.name))
 
             fields.append(
                 .named(
@@ -144,7 +144,7 @@ struct StructConverter: TypeConverter {
                 .callEncodeField(entity: expr)
 
             let def = TSVarDecl(
-                kind: .const, name: field.name,
+                kind: .const, name: TSKeyword.escaped(field.name),
                 initializer: expr
             )
 
@@ -152,7 +152,7 @@ struct StructConverter: TypeConverter {
         }
 
         for field in decl.storedProperties {
-            let expr = TSIdentExpr(field.name)
+            let expr = TSIdentExpr(TSKeyword.escaped(field.name))
 
             fields.append(
                 .named(

--- a/Sources/CodableToTypeScript/Value/TSKeyword.swift
+++ b/Sources/CodableToTypeScript/Value/TSKeyword.swift
@@ -1,0 +1,49 @@
+enum TSKeyword: String {
+    case `break`
+    case `case`
+    case `catch`
+    case `class`
+    case const
+    case `continue`
+    case debugger
+    case `default`
+    case delete
+    case `do`
+    case `else`
+    case export
+    case extends
+    case `false`
+    case finally
+    case `for`
+    case function
+    case `if`
+    case `import`
+    case `in`
+    case instanceof
+    case new
+    case null
+    case `return`
+    case `super`
+    case `switch`
+    case this
+    case `throw`
+    case `true`
+    case `try`
+    case typeof
+    case `var`
+    case void
+    case `while`
+    case with
+    case `let`
+    case `static`
+    case yield
+    case await
+
+    static func escaped(_ identifier: String) -> String {
+        if TSKeyword(rawValue: identifier) != nil {
+            return "_\(identifier)"
+        } else {
+            return identifier
+        }
+    }
+}

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -130,4 +130,63 @@ export function S_encode(entity: S): S_JSON {
             ]
         )
     }
+
+    func testVariableNameEscaping() throws {
+        try assertGenerate(
+            source: """
+struct S<T> {
+    var `class`: T
+}
+""",
+            expecteds: ["""
+export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
+    const _class = T_decode(json.class);
+    return {
+        class: _class
+    };
+}
+""", """
+export function S_encode<T, T_JSON>(entity: S<T>, T_encode: (entity: T) => T_JSON): S_JSON<T_JSON> {
+    const _class = T_encode(entity.class);
+    return {
+        class: _class
+    };
+}
+"""]
+        )
+
+            try assertGenerate(
+                source: """
+enum E<T> {
+    case `class`(break: T)
+}
+""",
+                expecteds: ["""
+export function E_decode<T, T_JSON>(json: E_JSON<T_JSON>, T_decode: (json: T_JSON) => T): E<T> {
+    if ("class" in json) {
+        const j = json.class;
+        const _break = T_decode(j.break);
+        return {
+            kind: "class",
+            class: {
+                break: _break
+            }
+        };
+    } else {
+        throw new Error("unknown kind");
+    }
+}
+""", """
+export function E_encode<T, T_JSON>(entity: E<T>, T_encode: (entity: T) => T_JSON): E_JSON<T_JSON> {
+    const e = entity.class;
+    const _break = T_encode(e.break);
+    return {
+        class: {
+            break: _break
+        }
+    };
+}
+"""]
+        )
+    }
 }


### PR DESCRIPTION
- https://github.com/omochi/CodableToTypeScript/issues/106

の問題を解決します。

`TSKeyword`を導入し、各種コード生成の動的な変数名を使う部分で毎回`TSKeyword`を使ってエスケープするようにしました。

`TSKeyword`をTypeScriptASTで管理するかこちらで管理するか悩みましたが、こちらで管理することにしました。
TypeScriptAST側では、オブジェクトのフィールド名に関しては使用できない文字列を自動でエスケープする処理があります。
同様に使用できない変数名をエスケープするのもTypeScriptAST側でやれば良いと思いましたが、オブジェクトのフィールド名と違って文法上エスケープ手段がなく、エスケープには独自のルールで変数名を変更する必要がありました。
変数名は宣言時だけでなく利用時もエスケープされた命名を利用する必要であるため、TypeScriptASTが勝手にエスケープすると利用時のエスケープ方法が難しく困るのではないかと思いました。よって、C2TS側でエスケープするということにしました。
