### PR TITLE
Call didGenerateEntry anytime

### DIFF
--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -32,7 +32,13 @@ public final class PackageGenerator {
     public let importFileExtension: ImportFileExtension
     public let outputDirectory: URL
     public let typeScriptExtension: String
-    public var didGenerateEntry: ((SourceFile, PackageEntry) throws -> Void)?
+    @available(*, deprecated, renamed: "didConvertSource")
+    public var didGenerateEntry: ((SourceFile, PackageEntry) throws -> Void)? {
+        get { didConvertSource }
+        set { didConvertSource = newValue }
+    }
+    public var didConvertSource: ((SourceFile, PackageEntry) throws -> Void)?
+
     public var didWrite: ((URL, Data) throws -> Void)?
 
     public struct GenerateResult {
@@ -58,7 +64,7 @@ public final class PackageGenerator {
                             file: try tsPath(module: module, file: source.file),
                             source: tsSource
                         )
-                        try didGenerateEntry?(source, entry)
+                        try didConvertSource?(source, entry)
 
                         if !entry.source.elements.isEmpty {
                             entries.append(entry)

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -54,14 +54,15 @@ public final class PackageGenerator {
                     collect {
                         let tsSource = try codeGenerator.convert(source: source)
 
-                        if tsSource.elements.isEmpty { return }
-
                         let entry = PackageEntry(
                             file: try tsPath(module: module, file: source.file),
                             source: tsSource
                         )
-                        entries.append(entry)
                         try didGenerateEntry?(source, entry)
+
+                        if !entry.source.elements.isEmpty {
+                            entries.append(entry)
+                        }
                     }
                 }
             }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -12,6 +12,7 @@ final class PackageGeneratorTests: XCTestCase {
         }
         """, file: URL(fileURLWithPath: "A.swift")).module
 
+        // case1: empty for C2TS
         let generator = PackageGenerator(
             context: context,
             symbols: SymbolTable(),
@@ -21,6 +22,7 @@ final class PackageGeneratorTests: XCTestCase {
         let result = try generator.generate(modules: [module])
         XCTAssertEqual(result.entries.count, 1) // helper library anytime generated
 
+        // case2: empty for C2TS, but not for the user
         let expectation = self.expectation(description: "didGenerateEntry called")
         generator.didGenerateEntry = { source, entry in
             entry.source.elements.append(TSCustomDecl(text: "/* hello */"))
@@ -28,7 +30,7 @@ final class PackageGeneratorTests: XCTestCase {
         }
         let result2 = try generator.generate(modules: [module])
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 3)
         XCTAssertEqual(result2.entries.count, 2)
     }
 }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -23,8 +23,8 @@ final class PackageGeneratorTests: XCTestCase {
         XCTAssertEqual(result.entries.count, 1) // helper library anytime generated
 
         // case2: empty for C2TS, but not for the user
-        let expectation = self.expectation(description: "didGenerateEntry called")
-        generator.didGenerateEntry = { source, entry in
+        let expectation = self.expectation(description: "didConvertSource called")
+        generator.didConvertSource = { source, entry in
             entry.source.elements.append(TSCustomDecl(text: "/* hello */"))
             expectation.fulfill()
         }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import SwiftTypeReader
+import TypeScriptAST
+import CodableToTypeScript
+
+final class PackageGeneratorTests: XCTestCase {
+    func testEmptyModule() throws {
+        let context = Context()
+        let module = Reader(context: context).read(source: """
+        protocol P {
+            func f()
+        }
+        """, file: URL(fileURLWithPath: "A.swift")).module
+
+        let generator = PackageGenerator(
+            context: context,
+            symbols: SymbolTable(),
+            importFileExtension: .js,
+            outputDirectory: URL(fileURLWithPath: "/dev/null", isDirectory: true)
+        )
+        let result = try generator.generate(modules: [module])
+        XCTAssertEqual(result.entries.count, 1) // helper library anytime generated
+
+        let expectation = self.expectation(description: "didGenerateEntry called")
+        generator.didGenerateEntry = { source, entry in
+            entry.source.elements.append(TSCustomDecl(text: "/* hello */"))
+            expectation.fulfill()
+        }
+        let result2 = try generator.generate(modules: [module])
+
+        wait(for: [expectation])
+        XCTAssertEqual(result2.entries.count, 2)
+    }
+}


### PR DESCRIPTION
PackageGeneratorに関する修正です。

対象ソースコードの中にC2TS的に生成するコードが存在しなかった場合に、`didGenerateEntry`が呼ばれない問題がありました。
これは、C2TS的には生成物がなかったとしても、PackageGeneratorを利用するコード的には生成物があるパターンにおいて、コード生成が中途半端にストップしてしまう問題を抱えていました。
`didGenerateEntry`は常に実行し、それを実行した上でなお生成コードが存在しない場合にそのファイルをスキップするよう変更します。