### PR TITLE
Upgrade to swift-syntax 590

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "cd793adf5680e138bf2bcbaacc292490175d0dcd",
-        "version" : "508.0.0"
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "18ee757dbb9aac67fdbb71545e8c246f4248cbb0",
-        "version" : "2.6.2"
+        "revision" : "d21bbe0e0598d1a9a80718f19ea7081053986e1c",
+        "version" : "2.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.6.2"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.7.0"),
         .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6"),
     ],
     targets: [

--- a/Sources/CodableToTypeScript/Extensions/STypeEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/STypeEx.swift
@@ -169,7 +169,7 @@ extension SType {
     }
 }
 
-extension ParamDecl {
+extension CaseParamDecl {
     var index: Int {
         if let caseElement = parentContext?.asEnumCaseElement {
             return caseElement.associatedValues.firstIndex(of: self)!


### PR DESCRIPTION
https://github.com/omochi/SwiftTypeReader/pull/50 の追従をする
結果的に孫依存するSwiftSyntaxのバージョン上がる
