### PR TITLE
Assume the output directory is basePath.

### DIFF
--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -112,7 +112,7 @@ public final class PackageGenerator {
     }
 
     private func path(_ name: String) -> URL {
-        URL(fileURLWithPath: name, relativeTo: outputDirectory)
+        return URL(fileURLWithPath: name, relativeTo: outputDirectory.appendingPathComponent("/"))
     }
 
     public func write(

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -82,7 +82,7 @@ public final class PackageGenerator {
 
         try withErrorCollector { collect in
             for entry in entries {
-                collect(at: "\(entry.file.lastPathComponent)") {
+                collect(at: "\(entry.file.relativePath)") {
                     let source = entry.source
                     let imports = try source.buildAutoImportDecls(
                         from: entry.file,
@@ -112,7 +112,7 @@ public final class PackageGenerator {
     }
 
     private func path(_ name: String) -> URL {
-        outputDirectory.appendingPathComponent(name)
+        URL(filePath: name, relativeTo: outputDirectory)
     }
 
     public func write(

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -112,7 +112,7 @@ public final class PackageGenerator {
     }
 
     private func path(_ name: String) -> URL {
-        URL(filePath: name, relativeTo: outputDirectory)
+        URL(fileURLWithPath: name, relativeTo: outputDirectory)
     }
 
     public func write(


### PR DESCRIPTION
軽微な修正です。
エラーの発生箇所をより明確にするために、エラー発生場所名を出力ファイル名だけでなく、モジュール名を含めたパスにします。


- 元々のエラー文

`"B.ts: unknown symbols: A"`

- 変更後のエラー文

`"B/B.ts: unknown symbols: A"`