### PR TITLE
PagageGeneratorで依存先モジュールの依存対象ファイルを生成対象にする

### DIFF
--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -131,6 +131,9 @@ public final class PackageGenerator {
                 for entry in entries where entry.isGenerationTarget && !entry.isGenerated {
                     collect(at: "\(entry.entry.file.relativePath)") {
                         let importedSymbols = try generateEntry(entry)
+                        if importedSymbols.isEmpty {
+                            return
+                        }
 
                         for entry in entries where !entry.isGenerationTarget && !entry.isGenerated {
                             if entry.symbols.table.keys.contains(where: {

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -145,9 +145,18 @@ public final class PackageGenerator {
             } while `continue`
         }
 
+        var generatedSymbols = self.symbols
+        try withErrorCollector { collect in
+            for entry in entries.filter(\.isGenerated) {
+                collect {
+                    try generatedSymbols.formUnion(entry.symbols)
+                }
+            }
+        }
+
         return GenerateResult(
             entries: entries.filter(\.isGenerated).map(\.entry),
-            symbols: allSymbols
+            symbols: generatedSymbols
         )
     }
 

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateErrorTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateErrorTests.swift
@@ -43,8 +43,8 @@ final class GenerateErrorTests: GenerateTestCaseBase {
         )
         XCTAssertThrowsError(try generator.generate(modules: [module])) { (error) in
             XCTAssertEqual("\(error)", """
-            S.t.b: Error type can't be evaluated: B
-            T.b: Error type can't be evaluated: B
+            B.swift.T.b: Error type can't be evaluated: B
+            A.swift.S.t.b: Error type can't be evaluated: B
             """)
         }
     }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -55,6 +55,13 @@ final class PackageGeneratorTests: XCTestCase {
         }
         """, file: URL(fileURLWithPath: "B.swift")).module
 
+        _ = Reader(
+            context: context,
+            module: context.getOrCreateModule(name: "C")
+        ).read(source: """
+        struct Unused: Codable {}
+        """, file: URL(fileURLWithPath: "C.swift"))
+
         let generator = PackageGenerator(
             context: context,
             symbols: SymbolTable(),
@@ -68,6 +75,9 @@ final class PackageGeneratorTests: XCTestCase {
         }))
         XCTAssertTrue(rootElements.contains(where: { element in
             return element.asDecl?.asType?.name == "B"
+        }))
+        XCTAssertFalse(rootElements.contains(where: { element in
+            return element.asDecl?.asType?.name == "Unused"
         }))
     }
 }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -61,6 +61,13 @@ final class PackageGeneratorTests: XCTestCase {
             importFileExtension: .js,
             outputDirectory: URL(fileURLWithPath: "/dev/null", isDirectory: true)
         )
-        XCTAssertNoThrow(try generator.generate(modules: [bModule]))
+        let result = try generator.generate(modules: [bModule])
+        let rootElements = result.entries.flatMap(\.source.elements)
+        XCTAssertTrue(rootElements.contains(where: { element in
+            return element.asDecl?.asType?.name == "A"
+        }))
+        XCTAssertTrue(rootElements.contains(where: { element in
+            return element.asDecl?.asType?.name == "B"
+        }))
     }
 }

--- a/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
+++ b/Tests/CodableToTypeScriptTests/PackageGeneratorTests.swift
@@ -66,7 +66,9 @@ final class PackageGeneratorTests: XCTestCase {
             context: context,
             module: context.getOrCreateModule(name: "C")
         ).read(source: """
-        struct UnusedC: Codable {}
+        struct NotTSConvertibleC: Codable {
+            var a: UnknownType
+        }
         """, file: URL(fileURLWithPath: "C.swift"))
 
         let dModule = Reader(
@@ -98,7 +100,7 @@ final class PackageGeneratorTests: XCTestCase {
             return element.asDecl?.asType?.name == "B"
         }))
         XCTAssertFalse(rootElements.contains(where: { element in
-            return element.asDecl?.asType?.name == "UnusedC"
+            return element.asDecl?.asType?.name == "NotTSConvertibleC"
         }))
         XCTAssertTrue(rootElements.contains(where: { element in
             return element.asDecl?.asType?.name == "D"


### PR DESCRIPTION
## 課題

Core ← Entities ← Appのように依存関係があるコードベースにおいて。
Entitiesの一部の型に対してコード生成を試みたい場合に、もしEntitiesがCoreの型に依存している場合、現在はCoreも明示的にコード生成をする必要があります。
ここで、実際に必要なCoreの型はごく少数で、Coreの全ての型を生成対象にしたくはありません。

## 方針

`PackageGenerator`は`context`と生成対象の`modules`をそれぞれ渡してコード生成を行うインターフェースとなっています。
もし`modules`が依存している型が`context`に含まれていた場合、その型もコード生成の対象となるようにします。

これにより、読み取りは広く行ってコード生成する範囲は狭くする、という運用が可能になります。
読み取りは未解決のシンボルなどを含められるため広く行うことができ、本当に必要な場面のみシンボルの解決が必要な形にすることで、C2TS導入の敷居を下げます。

## 変更内容

コード生成のロジックを全体的に改修し、以下の3つのステップに分けて実行します。

1. `context`から全ての型をスキャンして、exportされるTSシンボルを収集する
     - この際、エラーを無視することで変換できないファイルを読み取れるようにする
2. TSシンボルからそれが含まれるファイルを特定する逆引き辞書を作る
3. `modules`に指定された型についてTSへの変換を実行する。依存されたシンボルを2で作った辞書から調べ、まだ変換されてなければ変換キューに追加する。これをキューが空になるまで繰り返す。

注意点として、変換は型単位ではなくファイル単位となっています。これは単にファイル内のシンボル間依存関係も調べる必要があってそこまで頑張れてないからです。