### PR TITLE
Add Set converter

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/SwiftTypeReader",
       "state" : {
-        "revision" : "6a0fe53d83994eb91736ba2028f27eadfde35589",
-        "version" : "2.10.0"
+        "revision" : "075dcfe5d2d985fc69ee03919c17ceee62c07832",
+        "version" : "2.10.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/TypeScriptAST",
       "state" : {
-        "revision" : "d454923c7deba1fc6a9b04404e2cc5557b34a36c",
-        "version" : "1.8.6"
+        "revision" : "072d12c92272d4d162ead6845d7446ad34bfa99d",
+        "version" : "1.8.8"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.10.0"),
+        .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.10.1"),
 //        .package(path: "../SwiftTypeReader"),
         .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/omochi/SwiftTypeReader", from: "2.10.1"),
 //        .package(path: "../SwiftTypeReader"),
-        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.6"),
+        .package(url: "https://github.com/omochi/TypeScriptAST", from: "1.8.8"),
     ],
     targets: [
         .target(

--- a/Sources/CodableToTypeScript/Extensions/STypeEx.swift
+++ b/Sources/CodableToTypeScript/Extensions/STypeEx.swift
@@ -147,6 +147,13 @@ extension SType {
         return (array: array, element: element)
     }
 
+    internal func asSet() -> (set: StructType, element: any SType)? {
+        guard isStandardLibraryType("Set"),
+              let `set` = self.asStruct,
+              let element = `set`.genericArgs[safe: 0] else { return nil }
+        return (set: `set`, element: element)
+    }
+
     internal func asDictionary() -> (dictionary: StructType, value: any SType)? {
         guard isStandardLibraryType("Dictionary"),
               let dict = self.asStruct,

--- a/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
@@ -9,6 +9,8 @@ struct HelperLibraryGenerator {
         case optionalEncode
         case arrayDecode
         case arrayEncode
+        case setDecode
+        case setEncode
         case dictionaryDecode
         case dictionaryEncode
         case tagOf
@@ -36,6 +38,8 @@ struct HelperLibraryGenerator {
         case .optionalEncode: return "Optional_encode"
         case .arrayDecode: return "Array_decode"
         case .arrayEncode: return "Array_encode"
+        case .setDecode: return "Set_decode"
+        case .setEncode: return "Set_encode"
         case .dictionaryDecode: return "Dictionary_decode"
         case .dictionaryEncode: return "Dictionary_encode"
         case .tagOf: return "TagOf"
@@ -56,6 +60,8 @@ struct HelperLibraryGenerator {
         case .optionalEncode: return optionalEncodeDecl()
         case .arrayDecode: return arrayDecodeDecl()
         case .arrayEncode: return arrayEncodeDecl()
+        case .setDecode: return setDecodeDecl()
+        case .setEncode: return setEncodeDecl()
         case .dictionaryDecode: return dictionaryDecodeDecl()
         case .dictionaryEncode: return dictionaryEncodeDecl()
         case .tagOf: return tagOfDecl()
@@ -202,6 +208,58 @@ struct HelperLibraryGenerator {
                     TSCallExpr(
                         callee: TSMemberExpr(
                             base: TSIdentExpr.entity, name: "map"
+                        ),
+                        args: [tEncode()]
+                    )
+                )
+            ])
+        )
+    }
+
+    func setDecodeDecl() -> TSFunctionDecl {
+        return TSFunctionDecl(
+            modifiers: [.export],
+            name: name(.setDecode),
+            genericParams: [.init("T"), .init("T_JSON")],
+            params: [
+                .init(name: "json", type: TSArrayType(TSIdentType("T_JSON"))),
+                tDecodeParameter()
+            ],
+            result: TSIdentType("Set", genericArgs: [TSIdentType("T")]),
+            body: TSBlockStmt([
+                TSReturnStmt(
+                    TSNewExpr(
+                        callee: TSIdentType("Set"),
+                        args: [TSCallExpr(
+                            callee: TSMemberExpr(
+                                base: TSIdentExpr.json, name: "map"
+                            ),
+                            args: [tDecode()]
+                        )]
+                    )
+                )
+            ])
+        )
+    }
+
+    func setEncodeDecl() -> TSFunctionDecl {
+        return TSFunctionDecl(
+            modifiers: [.export],
+            name: name(.setEncode),
+            genericParams: [.init("T"), .init("T_JSON")],
+            params: [
+                .init(name: "entity", type: TSIdentType("Set", genericArgs: [TSIdentType("T")])),
+                tEncodeParameter()
+            ],
+            result: TSArrayType(TSIdentType("T_JSON")),
+            body: TSBlockStmt([
+                TSReturnStmt(
+                    TSCallExpr(
+                        callee: TSMemberExpr(
+                            base: TSArrayExpr([
+                                TSPrefixOperatorExpr("...", TSIdentExpr.entity),
+                            ]),
+                            name: "map"
                         ),
                         args: [tEncode()]
                     )

--- a/Sources/CodableToTypeScript/TypeConverter/SetConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/SetConverter.swift
@@ -1,0 +1,54 @@
+import SwiftTypeReader
+import TypeScriptAST
+
+public struct SetConverter: TypeConverter {
+    public init(generator: CodeGenerator, swiftType: any SType) {
+        self.generator = generator
+        self.swiftType = swiftType
+    }
+
+    public var generator: CodeGenerator
+    public var swiftType: any SType
+
+    private func element() throws -> any TypeConverter {
+        let (_, element) = swiftType.asSet()!
+        return try generator.converter(for: element)
+    }
+
+    public func type(for target: GenerationTarget) throws -> any TSType {
+        switch target {
+        case .entity:
+            return try `default`.type(for: target)
+        case .json:
+            return TSArrayType(try element().type(for: target))
+        }
+    }
+
+    public func typeDecl(for target: GenerationTarget) throws -> TSTypeDecl? {
+        throw MessageError("Unsupported type: \(swiftType)")
+    }
+
+    public func decodePresence() throws -> CodecPresence {
+        return .required
+    }
+
+    public func decodeName() throws -> String? {
+        return generator.helperLibrary().name(.setDecode)
+    }
+
+    public func decodeDecl() throws -> TSFunctionDecl? {
+        throw MessageError("Unsupported type: \(swiftType)")
+    }
+
+    public func encodePresence() throws -> CodecPresence {
+        return .required
+    }
+
+    public func encodeName() throws -> String {
+        return generator.helperLibrary().name(.setEncode)
+    }
+
+    public func encodeDecl() throws -> TSFunctionDecl? {
+        throw MessageError("Unsupported type: \(swiftType)")
+    }
+}

--- a/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/TypeConverterProvider.swift
@@ -28,6 +28,8 @@ public struct TypeConverterProvider {
             return OptionalConverter(generator: generator, swiftType: type)
         } else if type.isStandardLibraryType("Array") {
             return ArrayConverter(generator: generator, swiftType: type)
+        } else if type.isStandardLibraryType("Set") {
+            return SetConverter(generator: generator, swiftType: type)
         } else if type.isStandardLibraryType("Dictionary") {
             return DictionaryConverter(generator: generator, swiftType: type)
         } else if let type = type.asEnum {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
@@ -225,6 +225,42 @@ export function S_decode(json: S_JSON): S {
         )
     }
 
+    func testSet() throws {
+        try assertGenerate(
+            source: """
+enum E { case a }
+
+struct S {
+    var e1: Set<E>
+}
+""",
+            typeSelector: .name("S"),
+            expecteds: ["""
+export type S = {
+    e1: Set<E>;
+} & TagRecord<"S">;
+
+export type S_JSON = {
+    e1: E_JSON[];
+};
+
+export function S_decode(json: S_JSON): S {
+    const e1 = Set_decode<E, E_JSON>(json.e1, E_decode);
+    return {
+        e1: e1
+    };
+}
+
+export function S_encode(entity: S): S_JSON {
+    const e1 = Set_encode<E, E_JSON>(entity.e1, identity);
+    return {
+        e1: e1
+    };
+}
+"""]
+        )
+    }
+
     func testDecodeDictionary() throws {
         try assertGenerate(
             source: """

--- a/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
+++ b/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
@@ -44,6 +44,14 @@ export function Array_encode<T, T_JSON>(entity: T[], T_encode: (entity: T) => T_
     return entity.map(T_encode);
 }
 """, """
+export function Set_decode<T, T_JSON>(json: T_JSON[], T_decode: (json: T_JSON) => T): Set<T> {
+    return new Set(json.map(T_decode));
+}
+""", """
+export function Set_encode<T, T_JSON>(entity: Set<T>, T_encode: (entity: T) => T_JSON): T_JSON[] {
+    return [... entity].map(T_encode);
+}
+""", """
 export function Dictionary_decode<T, T_JSON>(json: {
     [key: string]: T_JSON;
 }, T_decode: (json: T_JSON) => T): Map<string, T> {


### PR DESCRIPTION
`Set`の変換をサポートします。

Swiftの`Set`はJSON表現では配列と同等となるため、JSON型は配列になっています。デコーダで配列をJavaScriptの`Set`に変換します。
特に機能的な大きな変更はなく、既存のConverterと同様の実装となっています。

https://github.com/omochi/TypeScriptAST/pull/41 が入るまで`Set`のシンボルが認識できないので、CIは落ちます。