### PR TITLE
Resume codec presence cache layer

### DIFF
--- a/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/CodeGenerator.swift
@@ -62,6 +62,40 @@ public final class CodeGenerator {
         }
     }
 
+    internal struct HasDecodeRequest: Request {
+        var token: RequestToken
+        @AnyTypeStorage var type: any SType
+
+        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+            do {
+                let converter = try token.generator.implConverter(for: type)
+                return try converter.hasDecode()
+            } catch {
+                switch error {
+                case is CycleRequestError: return true
+                default: throw error
+                }
+            }
+        }
+    }
+
+    internal struct HasEncodeRequest: Request {
+        var token: RequestToken
+        @AnyTypeStorage var type: any SType
+
+        func evaluate(on evaluator: RequestEvaluator) throws -> Bool {
+            do {
+                let converter = try token.generator.implConverter(for: type)
+                return try converter.hasEncode()
+            } catch {
+                switch error {
+                case is CycleRequestError: return true
+                default: throw error
+                }
+            }
+        }
+    }
+
     func helperLibrary() -> HelperLibraryGenerator {
         return HelperLibraryGenerator(generator: self)
     }

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -32,7 +32,9 @@ struct GeneratorProxyConverter: TypeConverter {
     }
 
     func hasDecode() throws -> Bool {
-        return try impl.hasDecode()
+        return try generator.context.evaluator(
+            CodeGenerator.HasDecodeRequest(token: generator.requestToken, type: swiftType)
+        )
     }
 
     func decodeName() throws -> String? {
@@ -60,7 +62,9 @@ struct GeneratorProxyConverter: TypeConverter {
     }
 
     func hasEncode() throws -> Bool {
-        return try impl.hasEncode()
+        return try generator.context.evaluator(
+            CodeGenerator.HasEncodeRequest(token: generator.requestToken, type: swiftType)
+        )
     }
 
     func encodeName() throws -> String {


### PR DESCRIPTION
https://github.com/omochi/CodableToTypeScript/pull/120 で `CodecPresence`に関する処理を削除しましたが、`GeneratorProxyConverter`が行っていたキャッシュ処理も含めて削除してしまいました。
これによりパフォーマンスの劣化が著しく、体感できるレベルで遅くなってしまいました。

以前の`CodecPresence`相当部分の処理であるhasDecode,hasEncodeの部分に対して同じような実装を埋め込んだところ改善しました。