### PR TITLE
Fix conformance mistake of decodeName

### DIFF
--- a/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/ArrayConverter.swift
@@ -29,7 +29,7 @@ public struct ArrayConverter: TypeConverter {
         return try element().hasDecode()
     }
 
-    public func decodeName() throws -> String? {
+    public func decodeName() throws -> String {
         return generator.helperLibrary().name(.arrayDecode)
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DictionaryConverter.swift
@@ -33,7 +33,7 @@ public struct DictionaryConverter: TypeConverter {
         return true
     }
 
-    public func decodeName() throws -> String? {
+    public func decodeName() throws -> String {
         return generator.helperLibrary().name(.dictionaryDecode)
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/GeneratorProxyConverter.swift
@@ -35,7 +35,7 @@ struct GeneratorProxyConverter: TypeConverter {
         return try impl.hasDecode()
     }
 
-    func decodeName() throws -> String? {
+    func decodeName() throws -> String {
         return try impl.decodeName()
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/OptionalConverter.swift
@@ -45,7 +45,7 @@ public struct OptionalConverter: TypeConverter {
         return try wrapped(limit: nil).hasDecode()
     }
 
-    public func decodeName() throws -> String? {
+    public func decodeName() throws -> String {
         return generator.helperLibrary().name(.optionalDecode)
     }
 

--- a/Sources/CodableToTypeScript/TypeConverter/SetConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/SetConverter.swift
@@ -32,7 +32,7 @@ public struct SetConverter: TypeConverter {
         return true
     }
 
-    public func decodeName() throws -> String? {
+    public func decodeName() throws -> String {
         return generator.helperLibrary().name(.setDecode)
     }
 


### PR DESCRIPTION
```
protocol TypeConverter {
    func decodeName() throws -> String
}
```

で定義されているものに対して、`func decodeName() throws -> String?`でconformしたつもりになっているクラスが散見された。
踏んで変なエラーになっていたことで発覚した。


テストは偶然壊れていなかった？