### PR TITLE
Change JSON type suffix to $JSON

### DIFF
--- a/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/HelperLibraryGenerator.swift
@@ -86,9 +86,9 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalFieldDecode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
-                .init(name: "json", type: TSUnionType(TSIdentType("T_JSON"), TSIdentType.undefined)),
+                .init(name: "json", type: TSUnionType(TSIdentType("T$JSON"), TSIdentType.undefined)),
                 tDecodeParameter()
             ],
             result: TSUnionType(TSIdentType("T"), TSIdentType.undefined),
@@ -108,12 +108,12 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalFieldEncode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
                 .init(name: "entity", type: TSUnionType(TSIdentType("T"), TSIdentType.undefined)),
                 tEncodeParameter()
             ],
-            result: TSUnionType(TSIdentType("T_JSON"), TSIdentType.undefined),
+            result: TSUnionType(TSIdentType("T$JSON"), TSIdentType.undefined),
             body: TSBlockStmt([
                 TSIfStmt(
                     condition: TSInfixOperatorExpr(
@@ -130,9 +130,9 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalDecode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
-                .init(name: "json", type: TSUnionType(TSIdentType("T_JSON"), TSIdentType.null)),
+                .init(name: "json", type: TSUnionType(TSIdentType("T$JSON"), TSIdentType.null)),
                 tDecodeParameter()
             ],
             result: TSUnionType(TSIdentType("T"), TSIdentType.null),
@@ -152,12 +152,12 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.optionalEncode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
                 .init(name: "entity", type: TSUnionType(TSIdentType("T"), TSIdentType.null)),
                 tEncodeParameter()
             ],
-            result: TSUnionType(TSIdentType("T_JSON"), TSIdentType.null),
+            result: TSUnionType(TSIdentType("T$JSON"), TSIdentType.null),
             body: TSBlockStmt([
                 TSIfStmt(
                     condition: TSInfixOperatorExpr(
@@ -174,9 +174,9 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.arrayDecode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
-                .init(name: "json", type: TSArrayType(TSIdentType("T_JSON"))),
+                .init(name: "json", type: TSArrayType(TSIdentType("T$JSON"))),
                 tDecodeParameter()
             ],
             result: TSArrayType(TSIdentType("T")),
@@ -197,12 +197,12 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.arrayEncode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
                 .init(name: "entity", type: TSArrayType(TSIdentType("T"))),
                 tEncodeParameter()
             ],
-            result: TSArrayType(TSIdentType("T_JSON")),
+            result: TSArrayType(TSIdentType("T$JSON")),
             body: TSBlockStmt([
                 TSReturnStmt(
                     TSCallExpr(
@@ -220,9 +220,9 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.setDecode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
-                .init(name: "json", type: TSArrayType(TSIdentType("T_JSON"))),
+                .init(name: "json", type: TSArrayType(TSIdentType("T$JSON"))),
                 tDecodeParameter()
             ],
             result: TSIdentType("Set", genericArgs: [TSIdentType("T")]),
@@ -246,12 +246,12 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.setEncode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
                 .init(name: "entity", type: TSIdentType("Set", genericArgs: [TSIdentType("T")])),
                 tEncodeParameter()
             ],
-            result: TSArrayType(TSIdentType("T_JSON")),
+            result: TSArrayType(TSIdentType("T$JSON")),
             body: TSBlockStmt([
                 TSReturnStmt(
                     TSCallExpr(
@@ -272,9 +272,9 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.dictionaryDecode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
-                .init(name: "json", type: TSObjectType.dictionary(TSIdentType("T_JSON"))),
+                .init(name: "json", type: TSObjectType.dictionary(TSIdentType("T$JSON"))),
                 tDecodeParameter()
             ],
             result: TSIdentType.map(TSIdentType.string, TSIdentType("T")),
@@ -322,15 +322,15 @@ struct HelperLibraryGenerator {
         return TSFunctionDecl(
             modifiers: [.export],
             name: name(.dictionaryEncode),
-            genericParams: [.init("T"), .init("T_JSON")],
+            genericParams: [.init("T"), .init("T$JSON")],
             params: [
                 .init(name: "entity", type: TSIdentType.map(TSIdentType.string, TSIdentType("T"))),
                 tEncodeParameter()
             ],
-            result: TSObjectType.dictionary(TSIdentType("T_JSON")),
+            result: TSObjectType.dictionary(TSIdentType("T$JSON")),
             body: TSBlockStmt([
                 TSVarDecl(
-                    kind: .const, name: "json", type: TSObjectType.dictionary(TSIdentType("T_JSON")),
+                    kind: .const, name: "json", type: TSObjectType.dictionary(TSIdentType("T$JSON")),
                     initializer: TSObjectExpr([])
                 ),
                 TSForInStmt(
@@ -439,7 +439,7 @@ struct HelperLibraryGenerator {
         return TSFunctionType.Param(
             name: tDecode().name,
             type: TSFunctionType(
-                params: [.init(name: "json", type: TSIdentType("T_JSON"))],
+                params: [.init(name: "json", type: TSIdentType("T$JSON"))],
                 result: TSIdentType("T")
             )
         )
@@ -463,7 +463,7 @@ struct HelperLibraryGenerator {
             name: tEncode().name,
             type: TSFunctionType(
                 params: [.init(name: "entity", type: TSIdentType("T"))],
-                result: TSIdentType("T_JSON")
+                result: TSIdentType("T$JSON")
             )
         )
     }

--- a/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/DefaultTypeConverter.swift
@@ -38,7 +38,7 @@ public struct DefaultTypeConverter {
     }
 
     public static func jsonName(entityName: String) -> String {
-        return "\(entityName)_JSON"
+        return "\(entityName)$JSON"
     }
 
     public func hasJSONType() throws -> Bool {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeConverterTests.swift
@@ -69,12 +69,12 @@ struct S {
 """,
             typeConverterProvider: typeConverterProvider,
             externalReference: ExternalReference(
-                symbols: ["Custom", "Custom_JSON", "Custom_decode", "Custom_encode"],
+                symbols: ["Custom", "Custom$JSON", "Custom_decode", "Custom_encode"],
                 code: """
                 export type Custom = {};
-                export type Custom_JSON = string;
-                export function Custom_decode(json: Custom_JSON): Custom { throw 0; }
-                export function Custom_encode(entity: Custom): Custom_JSON { throw 0; }
+                export type Custom$JSON = string;
+                export function Custom_decode(json: Custom$JSON): Custom { throw 0; }
+                export function Custom_encode(entity: Custom): Custom$JSON { throw 0; }
                 """
             ),
             expecteds: ["""
@@ -84,17 +84,17 @@ export type S = {
     c: Custom[][];
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
-    a: Custom_JSON;
-    b: Custom_JSON[];
-    c: Custom_JSON[][];
+export type S$JSON = {
+    a: Custom$JSON;
+    b: Custom$JSON[];
+    c: Custom$JSON[][];
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Custom_decode(json.a);
-    const b = Array_decode<Custom, Custom_JSON>(json.b, Custom_decode);
-    const c = Array_decode<Custom[], Custom_JSON[]>(json.c, (json: Custom_JSON[]): Custom[] => {
-        return Array_decode<Custom, Custom_JSON>(json, Custom_decode);
+    const b = Array_decode<Custom, Custom$JSON>(json.b, Custom_decode);
+    const c = Array_decode<Custom[], Custom$JSON[]>(json.c, (json: Custom$JSON[]): Custom[] => {
+        return Array_decode<Custom, Custom$JSON>(json, Custom_decode);
     });
     return {
         a: a,
@@ -103,11 +103,11 @@ export function S_decode(json: S_JSON): S {
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     const a = Custom_encode(entity.a);
-    const b = Array_encode<Custom, Custom_JSON>(entity.b, Custom_encode);
-    const c = Array_encode<Custom[], Custom_JSON[]>(entity.c, (entity: Custom[]): Custom_JSON[] => {
-        return Array_encode<Custom, Custom_JSON>(entity, Custom_encode);
+    const b = Array_encode<Custom, Custom$JSON>(entity.b, Custom_encode);
+    const c = Array_encode<Custom[], Custom$JSON[]>(entity.c, (entity: Custom[]): Custom$JSON[] => {
+        return Array_encode<Custom, Custom$JSON>(entity, Custom_encode);
     });
     return {
         a: a,

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateCustomTypeMapTests.swift
@@ -53,11 +53,11 @@ export type S = {
     a: Date;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Date_decode(json.a);
     return {
         a: a
@@ -100,13 +100,13 @@ export type S = {
     c: Date[][];
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
     b: string[];
     c: string[][];
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Date_decode(json.a);
     const b = Array_decode<Date, string>(json.b, Date_decode);
     const c = Array_decode<Date[], string[]>(json.c, (json: string[]): Date[] => {
@@ -148,11 +148,11 @@ export type S = {
     a: Date;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
 };
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     const a = Date_encode(entity.a);
     return {
         a: a
@@ -194,18 +194,18 @@ export type S = {
     a: Date;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Date_decode(json.a);
     return {
         a: a
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     const a = Date_encode(entity.a);
     return {
         a: a
@@ -223,7 +223,7 @@ export function S_encode(entity: S): S_JSON {
             decode: "Date_decode", encode: "Date_encode"
         )
         typeMap.table["Vector2"] = .coding(
-            entityType: "Vector2", jsonType: "Vector2_JSON",
+            entityType: "Vector2", jsonType: "Vector2$JSON",
             decode: "Vector2_decode", encode: "Vector2_encode"
         )
 
@@ -239,16 +239,16 @@ struct S {
             externalReference: ExternalReference(
                 symbols: [
                     "Date_decode", "Date_encode",
-                    "Vector2", "Vector2_JSON",
+                    "Vector2", "Vector2$JSON",
                     "Vector2_decode", "Vector2_encode"
                 ],
                 code: """
                 export function Date_decode(json: string): Date { throw 0; }
                 export function Date_encode(date: Date): string { throw 0; }
                 export type Vector2<T> = {};
-                export type Vector2_JSON<T> = string;
-                export function Vector2_decode<T, TJ>(json: Vector2_JSON<TJ>, t: (j: TJ) => T): Vector2<T> { throw 0; }
-                export function Vector2_encode<T, TJ>(date: Vector2<T>, t: (e: T) => TJ): Vector2_JSON<TJ> { throw 0; }
+                export type Vector2$JSON<T> = string;
+                export function Vector2_decode<T, TJ>(json: Vector2$JSON<TJ>, t: (j: TJ) => T): Vector2<T> { throw 0; }
+                export function Vector2_encode<T, TJ>(date: Vector2<T>, t: (e: T) => TJ): Vector2$JSON<TJ> { throw 0; }
                 """
             ),
             expecteds: ["""
@@ -258,17 +258,17 @@ export type S = {
     c: Vector2<Vector2<number>>[];
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
-    a: Vector2_JSON<number>;
-    b: Vector2_JSON<string>;
-    c: Vector2_JSON<Vector2_JSON<number>>[];
+export type S$JSON = {
+    a: Vector2$JSON<number>;
+    b: Vector2$JSON<string>;
+    c: Vector2$JSON<Vector2$JSON<number>>[];
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Vector2_decode<number, number>(json.a, identity);
     const b = Vector2_decode<Date, string>(json.b, Date_decode);
-    const c = Array_decode<Vector2<Vector2<number>>, Vector2_JSON<Vector2_JSON<number>>>(json.c, (json: Vector2_JSON<Vector2_JSON<number>>): Vector2<Vector2<number>> => {
-        return Vector2_decode<Vector2<number>, Vector2_JSON<number>>(json, (json: Vector2_JSON<number>): Vector2<number> => {
+    const c = Array_decode<Vector2<Vector2<number>>, Vector2$JSON<Vector2$JSON<number>>>(json.c, (json: Vector2$JSON<Vector2$JSON<number>>): Vector2<Vector2<number>> => {
+        return Vector2_decode<Vector2<number>, Vector2$JSON<number>>(json, (json: Vector2$JSON<number>): Vector2<number> => {
             return Vector2_decode<number, number>(json, identity);
         });
     });
@@ -335,7 +335,7 @@ export type S
     func testMapUserTypeCodec() throws {
         var typeMap = TypeMap()
         typeMap.table["S"] = .coding(
-            entityType: "V", jsonType: "V_JSON",
+            entityType: "V", jsonType: "V$JSON",
             decode: "V_decode", encode: "V_encode"
         )
         try assertGenerate(

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEncodeTests.swift
@@ -23,7 +23,7 @@ export type E = ({
     };
 }) & TagRecord<"E">;
 """, """
-export type E_JSON = {
+export type E$JSON = {
     a: {};
 } | {
     b: {
@@ -31,7 +31,7 @@ export type E_JSON = {
     };
 };
 """, """
-export function E_encode(entity: E): E_JSON {
+export function E_encode(entity: E): E$JSON {
     switch (entity.kind) {
     case "a":
         {
@@ -78,14 +78,14 @@ export type S = {
     d: Date[];
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
     b?: string;
     c?: string | null;
     d: string[];
 };
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     const a = Date_encode(entity.a);
     const b = OptionalField_encode<Date, string>(entity.b, Date_encode);
     const c = OptionalField_encode<Date | null, string | null>(entity.c, (entity: Date | null): string | null => {
@@ -118,8 +118,8 @@ struct S {
             typeMap: dateTypeMap(),
             externalReference: dateTypeExternal(),
             expecteds: ["""
-export function S_encode(entity: S): S_JSON {
-    const a = entity.a as E_JSON;
+export function S_encode(entity: S): S$JSON {
+    const a = entity.a as E$JSON;
     const b = Date_encode(entity.b);
     return {
         a: a,
@@ -139,14 +139,14 @@ struct S<T> {
 }
 """,
             expecteds: ["""
-export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
     const _class = T_decode(json.class);
     return {
         class: _class
     };
 }
 """, """
-export function S_encode<T, T_JSON>(entity: S<T>, T_encode: (entity: T) => T_JSON): S_JSON<T_JSON> {
+export function S_encode<T, T$JSON>(entity: S<T>, T_encode: (entity: T) => T$JSON): S$JSON<T$JSON> {
     const _class = T_encode(entity.class);
     return {
         class: _class
@@ -162,7 +162,7 @@ enum E<T> {
 }
 """,
                 expecteds: ["""
-export function E_decode<T, T_JSON>(json: E_JSON<T_JSON>, T_decode: (json: T_JSON) => T): E<T> {
+export function E_decode<T, T$JSON>(json: E$JSON<T$JSON>, T_decode: (json: T$JSON) => T): E<T> {
     if ("class" in json) {
         const j = json.class;
         const _break = T_decode(j.break);
@@ -177,7 +177,7 @@ export function E_decode<T, T_JSON>(json: E_JSON<T_JSON>, T_decode: (json: T_JSO
     }
 }
 """, """
-export function E_encode<T, T_JSON>(entity: E<T>, T_encode: (entity: T) => T_JSON): E_JSON<T_JSON> {
+export function E_encode<T, T$JSON>(entity: E<T>, T_encode: (entity: T) => T$JSON): E$JSON<T$JSON> {
     const e = entity.class;
     const _break = T_encode(e.break);
     return {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -21,7 +21,7 @@ export type E = ({
     };
 }) & TagRecord<"E">;
 ""","""
-export type E_JSON = {
+export type E$JSON = {
     a: {};
 } | {
     b: {
@@ -29,7 +29,7 @@ export type E_JSON = {
     };
 };
 ""","""
-export function E_decode(json: E_JSON): E {
+export function E_decode(json: E$JSON): E {
     if ("a" in json) {
         return {
             kind: "a",
@@ -75,7 +75,7 @@ export type E = ({
     };
 }) & TagRecord<"E">;
 """, """
-export type E_JSON = {
+export type E$JSON = {
     a: {
         x: number;
     };
@@ -123,7 +123,7 @@ export type E = {
     };
 } & TagRecord<"E">;
 """, """
-export type E_JSON = {
+export type E$JSON = {
     a: {
         _0: number;
         _1?: number;
@@ -132,7 +132,7 @@ export type E_JSON = {
     };
 };
 """, """
-export function E_decode(json: E_JSON): E {
+export function E_decode(json: E$JSON): E {
     if ("a" in json) {
         const j = json.a;
         const _0 = j._0;
@@ -255,9 +255,9 @@ enum E: Int, Codable, Sendable {
             expecteds: ["""
 export type E = "a" | "b" | "c";
 """, """
-export type E_JSON = 0 | -100 | -99;
+export type E$JSON = 0 | -100 | -99;
 """, """
-export function E_decode(json: E_JSON): E {
+export function E_decode(json: E$JSON): E {
     switch (json) {
     case 0:
         return "a";
@@ -268,7 +268,7 @@ export function E_decode(json: E_JSON): E {
     }
 }
 """, """
-export function E_encode(entity: E): E_JSON {
+export function E_encode(entity: E): E$JSON {
     switch (entity) {
     case "a":
         return 0;
@@ -303,7 +303,7 @@ enum E {
 """,
             typeSelector: .name("E"),
             expecteds: ["""
-export function E_decode(json: E_JSON): E {
+export function E_decode(json: E$JSON): E {
     if ("k" in json) {
         const j = json.k;
         const _0 = K_decode(j._0);

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateExampleTests.swift
@@ -50,7 +50,7 @@ export type E = ({
     };
 }) & TagRecord<"E">;
 """, """
-export type E_JSON = {
+export type E$JSON = {
     a: {
         x: number;
         y: number;
@@ -61,7 +61,7 @@ export type E_JSON = {
     };
 };
 """, """
-export function E_decode(json: E_JSON): E {
+export function E_decode(json: E$JSON): E {
     if ("a" in json) {
         const j = json.a;
         const x = j.x;
@@ -108,7 +108,7 @@ struct S {
             expecteds: ["""
 import {
     E1,
-    E1_JSON,
+    E1$JSON,
     E1_decode,
     E2,
     TagRecord
@@ -119,12 +119,12 @@ export type S = {
     y: E2;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
-    x: E1_JSON;
+export type S$JSON = {
+    x: E1$JSON;
     y: E2;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const x = E1_decode(json.x);
     const y = json.y;
     return {
@@ -152,7 +152,7 @@ enum R<T> {
         expecteds: ["""
 import {
     E,
-    E_JSON,
+    E$JSON,
     E_decode,
     TagRecord
 } from "..";
@@ -169,17 +169,17 @@ export type R<T> = ({
     };
 }) & TagRecord<"R", [T]>;
 """, """
-export type R_JSON<T_JSON> = {
+export type R$JSON<T$JSON> = {
     s: {
-        _0: T_JSON;
+        _0: T$JSON;
     };
 } | {
     f: {
-        _0: E_JSON;
+        _0: E$JSON;
     };
 };
 """, """
-export function R_decode<T, T_JSON>(json: R_JSON<T_JSON>, T_decode: (json: T_JSON) => T): R<T> {
+export function R_decode<T, T$JSON>(json: R$JSON<T$JSON>, T_decode: (json: T$JSON) => T): R<T> {
     if ("s" in json) {
         const j = json.s;
         const _0 = T_decode(j._0);
@@ -237,12 +237,12 @@ export type S = {
     b: S_K;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: string;
-    b: S_K_JSON;
+    b: S_K$JSON;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = json.a;
     const b = S_K_decode(json.b);
     return {
@@ -255,11 +255,11 @@ export type S_K = {
     a: E;
 } & TagRecord<"S_K">;
 """, """
-export type S_K_JSON = {
-    a: E_JSON;
+export type S_K$JSON = {
+    a: E$JSON;
 };
 """, """
-export function S_K_decode(json: S_K_JSON): S_K {
+export function S_K_decode(json: S_K$JSON): S_K {
     const a = E_decode(json.a);
     return {
         a: a

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateGenericTests.swift
@@ -14,11 +14,11 @@ export type S<T> = {
     a: T;
 } & TagRecord<"S", [T]>;
 """, """
-export type S_JSON<T_JSON> = {
-    a: T_JSON;
+export type S$JSON<T$JSON> = {
+    a: T$JSON;
 };
 """, """
-export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
     const a = T_decode(json.a);
     return {
         a: a
@@ -39,9 +39,9 @@ export type S<T> = {
 } & TagRecord<"S", [T]>;
 """],
             unexpecteds: ["""
-export type S_JSON<T_JSON>
+export type S$JSON<T$JSON>
 """, """
-export function S_decode<T, T_JSON>
+export function S_decode<T, T$JSON>
 """]
         )
     }
@@ -64,7 +64,7 @@ export type S = {
 """
             ],
             unexpecteds: ["""
-export type S_JSON
+export type S$JSON
 """, """
 export function S_decode
 """, """
@@ -92,12 +92,12 @@ export type S = {
     a: K<E>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
-    a: K_JSON<E_JSON>;
+export type S$JSON = {
+    a: K$JSON<E$JSON>;
 };
 """, """
-export function S_decode(json: S_JSON): S {
-    const a = K_decode<E, E_JSON>(json.a, E_decode);
+export function S_decode(json: S$JSON): S {
+    const a = K_decode<E, E$JSON>(json.a, E_decode);
     return {
         a: a
     };
@@ -121,17 +121,17 @@ export type S<A, B> = {
     b: B;
 } & TagRecord<"S", [A, B]>;
 """, """
-export type S_JSON<A_JSON, B_JSON> = {
-    a: A_JSON;
-    b: B_JSON;
+export type S$JSON<A$JSON, B$JSON> = {
+    a: A$JSON;
+    b: B$JSON;
 };
 """, """
 export function S_decode<
     A,
-    A_JSON,
+    A$JSON,
     B,
-    B_JSON
->(json: S_JSON<A_JSON, B_JSON>, A_decode: (json: A_JSON) => A, B_decode: (json: B_JSON) => B): S<A, B> {
+    B$JSON
+>(json: S$JSON<A$JSON, B$JSON>, A_decode: (json: A$JSON) => A, B_decode: (json: B$JSON) => B): S<A, B> {
     const a = A_decode(json.a);
     const b = B_decode(json.b);
     return {
@@ -159,24 +159,24 @@ export type S<A, B, C> = {
     c: C;
 } & TagRecord<"S", [A, B, C]>;
 """, """
-export type S_JSON<A_JSON, B_JSON, C_JSON> = {
-    a: A_JSON;
-    b: B_JSON;
-    c: C_JSON;
+export type S$JSON<A$JSON, B$JSON, C$JSON> = {
+    a: A$JSON;
+    b: B$JSON;
+    c: C$JSON;
 };
 """, """
 export function S_decode<
     A,
-    A_JSON,
+    A$JSON,
     B,
-    B_JSON,
+    B$JSON,
     C,
-    C_JSON
+    C$JSON
 >(
-    json: S_JSON<A_JSON, B_JSON, C_JSON>,
-    A_decode: (json: A_JSON) => A,
-    B_decode: (json: B_JSON) => B,
-    C_decode: (json: C_JSON) => C
+    json: S$JSON<A$JSON, B$JSON, C$JSON>,
+    A_decode: (json: A$JSON) => A,
+    B_decode: (json: B$JSON) => B,
+    C_decode: (json: C$JSON) => C
 ): S<A, B, C> {
     const a = A_decode(json.a);
     const b = B_decode(json.b);
@@ -215,15 +215,15 @@ export type S<T> = {
     c: X<T>;
 } & TagRecord<"S", [T]>;
 """, """
-export type S_JSON<T_JSON> = {
-    a: K_JSON<T_JSON>;
-    b: L_JSON<T_JSON>;
-    c: X<T_JSON>;
+export type S$JSON<T$JSON> = {
+    a: K$JSON<T$JSON>;
+    b: L$JSON<T$JSON>;
+    c: X<T$JSON>;
 };
 """, """
-export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
-    const a = K_decode<T, T_JSON>(json.a, T_decode);
-    const b = L_decode<T, T_JSON>(json.b, T_decode);
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
+    const a = K_decode<T, T$JSON>(json.a, T_decode);
+    const b = L_decode<T, T$JSON>(json.b, T_decode);
     const c = json.c as X<T>;
     return {
         a: a,
@@ -262,32 +262,32 @@ export type S<T, U> = {
     d: L<T, U>;
 } & TagRecord<"S", [T, U]>;
 """, """
-export type S_JSON<T_JSON, U_JSON> = {
-    a: K_JSON<T_JSON>;
-    b: K_JSON<U_JSON>;
-    c: L_JSON<T_JSON, T_JSON>;
-    d: L_JSON<T_JSON, U_JSON>;
+export type S$JSON<T$JSON, U$JSON> = {
+    a: K$JSON<T$JSON>;
+    b: K$JSON<U$JSON>;
+    c: L$JSON<T$JSON, T$JSON>;
+    d: L$JSON<T$JSON, U$JSON>;
 };
 """, """
 export function S_decode<
     T,
-    T_JSON,
+    T$JSON,
     U,
-    U_JSON
->(json: S_JSON<T_JSON, U_JSON>, T_decode: (json: T_JSON) => T, U_decode: (json: U_JSON) => U): S<T, U> {
-    const a = K_decode<T, T_JSON>(json.a, T_decode);
-    const b = K_decode<U, U_JSON>(json.b, U_decode);
+    U$JSON
+>(json: S$JSON<T$JSON, U$JSON>, T_decode: (json: T$JSON) => T, U_decode: (json: U$JSON) => U): S<T, U> {
+    const a = K_decode<T, T$JSON>(json.a, T_decode);
+    const b = K_decode<U, U$JSON>(json.b, U_decode);
     const c = L_decode<
         T,
-        T_JSON,
+        T$JSON,
         T,
-        T_JSON
+        T$JSON
     >(json.c, T_decode, T_decode);
     const d = L_decode<
         T,
-        T_JSON,
+        T$JSON,
         U,
-        U_JSON
+        U$JSON
     >(json.d, T_decode, U_decode);
     return {
         a: a,
@@ -331,17 +331,17 @@ export type S = {
     c: K<C>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     i: K<number>;
     a: K<A>;
-    b: K_JSON<B_JSON>;
+    b: K$JSON<B$JSON>;
     c: K<C>;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const i = json.i as K<number>;
     const a = json.a as K<A>;
-    const b = K_decode<B, B_JSON>(json.b, B_decode);
+    const b = K_decode<B, B$JSON>(json.b, B_decode);
     const c = json.c as K<C>;
     return {
         i: i,
@@ -379,21 +379,21 @@ export type S = {
     d: K<E[]>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: K<number | null>;
     b: K<number[]>;
-    c: K_JSON<E_JSON | null>;
-    d: K_JSON<E_JSON[]>;
+    c: K$JSON<E$JSON | null>;
+    d: K$JSON<E$JSON[]>;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = json.a as K<number | null>;
     const b = json.b as K<number[]>;
-    const c = K_decode<E | null, E_JSON | null>(json.c, (json: E_JSON | null): E | null => {
-        return Optional_decode<E, E_JSON>(json, E_decode);
+    const c = K_decode<E | null, E$JSON | null>(json.c, (json: E$JSON | null): E | null => {
+        return Optional_decode<E, E$JSON>(json, E_decode);
     });
-    const d = K_decode<E[], E_JSON[]>(json.d, (json: E_JSON[]): E[] => {
-        return Array_decode<E, E_JSON>(json, E_decode);
+    const d = K_decode<E[], E$JSON[]>(json.d, (json: E$JSON[]): E[] => {
+        return Array_decode<E, E$JSON>(json, E_decode);
     });
     return {
         a: a,
@@ -424,17 +424,17 @@ export type S<T> = {
     b: K<T[]>;
 } & TagRecord<"S", [T]>;
 """, """
-export type S_JSON<T_JSON> = {
-    a: K_JSON<T_JSON | null>;
-    b: K_JSON<T_JSON[]>;
+export type S$JSON<T$JSON> = {
+    a: K$JSON<T$JSON | null>;
+    b: K$JSON<T$JSON[]>;
 };
 """, """
-export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
-    const a = K_decode<T | null, T_JSON | null>(json.a, (json: T_JSON | null): T | null => {
-        return Optional_decode<T, T_JSON>(json, T_decode);
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
+    const a = K_decode<T | null, T$JSON | null>(json.a, (json: T$JSON | null): T | null => {
+        return Optional_decode<T, T$JSON>(json, T_decode);
     });
-    const b = K_decode<T[], T_JSON[]>(json.b, (json: T_JSON[]): T[] => {
-        return Array_decode<T, T_JSON>(json, T_decode);
+    const b = K_decode<T[], T$JSON[]>(json.b, (json: T$JSON[]): T[] => {
+        return Array_decode<T, T$JSON>(json, T_decode);
     });
     return {
         a: a,
@@ -460,13 +460,13 @@ export type E<T> = {
     };
 } & TagRecord<"E", [T]>;
 ""","""
-export type E_JSON<T_JSON> = {
+export type E$JSON<T$JSON> = {
     a: {
-        _0: T_JSON;
+        _0: T$JSON;
     };
 };
 ""","""
-export function E_decode<T, T_JSON>(json: E_JSON<T_JSON>, T_decode: (json: T_JSON) => T): E<T> {
+export function E_decode<T, T$JSON>(json: E$JSON<T$JSON>, T_decode: (json: T$JSON) => T): E<T> {
     if ("a" in json) {
         const j = json.a;
         const _0 = T_decode(j._0);
@@ -514,8 +514,8 @@ export type S_K<X> = {
     x: X;
 } & TagRecord<"S_K", [X]>;
 """, """
-export type S_K_JSON<X_JSON> = {
-    x: X_JSON;
+export type S_K$JSON<X$JSON> = {
+    x: X$JSON;
 };
 """])
     }
@@ -546,15 +546,15 @@ export type U = {
     k3: S_K<number>;
 } & TagRecord<"U">;
 """, """
-export type U_JSON = {
-    k: S_K_JSON<E_JSON>;
-    k2: S_K2_JSON<E_JSON>;
+export type U$JSON = {
+    k: S_K$JSON<E$JSON>;
+    k2: S_K2$JSON<E$JSON>;
     k3: S_K<number>;
 };
 """, """
-export function U_decode(json: U_JSON): U {
-    const k = S_K_decode<E, E_JSON>(json.k, E_decode);
-    const k2 = S_K2_decode<E, E_JSON>(json.k2, E_decode);
+export function U_decode(json: U$JSON): U {
+    const k = S_K_decode<E, E$JSON>(json.k, E_decode);
+    const k2 = S_K2_decode<E, E$JSON>(json.k2, E_decode);
     const k3 = json.k3 as S_K<number>;
     return {
         k: k,
@@ -623,28 +623,28 @@ export type K<T> = {
     k: S_G<E, T>;
 } & TagRecord<"K", [T]>;
 """, """
-export type K_JSON<T_JSON> = {
-    k: S_G_JSON<E_JSON, T_JSON>;
+export type K$JSON<T$JSON> = {
+    k: S_G$JSON<E$JSON, T$JSON>;
 };
 """, """
-export function K_decode<T, T_JSON>(json: K_JSON<T_JSON>, T_decode: (json: T_JSON) => T): K<T> {
+export function K_decode<T, T$JSON>(json: K$JSON<T$JSON>, T_decode: (json: T$JSON) => T): K<T> {
     const k = S_G_decode<
         E,
-        E_JSON,
+        E$JSON,
         T,
-        T_JSON
+        T$JSON
     >(json.k, E_decode, T_decode);
     return {
         k: k
     };
 }
 """, """
-export function K_encode<T, T_JSON>(entity: K<T>, T_encode: (entity: T) => T_JSON): K_JSON<T_JSON> {
+export function K_encode<T, T$JSON>(entity: K<T>, T_encode: (entity: T) => T$JSON): K$JSON<T$JSON> {
     const k = S_G_encode<
         E,
-        E_JSON,
+        E$JSON,
         T,
-        T_JSON
+        T$JSON
     >(entity.k, identity, T_encode);
     return {
         k: k

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateImportTests.swift
@@ -83,10 +83,10 @@ enum X {
             expecteds: ["""
 import {
     E,
-    E_JSON,
+    E$JSON,
     E_decode,
     S,
-    S_JSON,
+    S$JSON,
     S_decode,
     TagRecord
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateNestedTests.swift
@@ -84,9 +84,9 @@ export type A
 """, """
 export type A_B
 """, """
-export type A_B_JSON
+export type A_B$JSON
 """, """
-export function A_B_decode(json: A_B_JSON): A_B
+export function A_B_decode(json: A_B$JSON): A_B
 """
             ]
         )

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateRawRepresentableTests.swift
@@ -15,15 +15,15 @@ export type S = {
     rawValue: string;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = string;
+export type S$JSON = string;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue;
 }
 """
@@ -47,18 +47,18 @@ export type K = {
     a: S;
 }
 """, """
-export type K_JSON = {
-    a: S_JSON;
+export type K$JSON = {
+    a: S$JSON;
 };
 """, """
-export function K_decode(json: K_JSON): K {
+export function K_decode(json: K$JSON): K {
     const a = S_decode(json.a);
     return {
         a: a
     };
 }
 """, """
-export function K_encode(entity: K): K_JSON {
+export function K_encode(entity: K): K$JSON {
     const a = S_encode(entity.a);
     return {
         a: a
@@ -81,15 +81,15 @@ export type S = {
     rawValue: string;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = string;
+export type S$JSON = string;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue;
 }
 """
@@ -137,16 +137,16 @@ export type S = {
     rawValue?: K;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K_JSON | null;
+export type S$JSON = K$JSON | null;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
-        rawValue: Optional_decode<K, K_JSON>(json, K_decode) ?? undefined
+        rawValue: Optional_decode<K, K$JSON>(json, K_decode) ?? undefined
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
-    return OptionalField_encode<K, K_JSON>(entity.rawValue, K_encode) ?? null;
+export function S_encode(entity: S): S$JSON {
+    return OptionalField_encode<K, K$JSON>(entity.rawValue, K_encode) ?? null;
 }
 """
        ])
@@ -165,15 +165,15 @@ export type S = {
     rawValue?: number | null;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = number | null;
+export type S$JSON = number | null;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json as number | null ?? undefined
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue ?? null;
 }
 """
@@ -197,17 +197,17 @@ export type S = {
     rawValue?: K | null;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K_JSON | null;
+export type S$JSON = K$JSON | null;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
-        rawValue: Optional_decode<K, K_JSON>(json, K_decode) ?? undefined
+        rawValue: Optional_decode<K, K$JSON>(json, K_decode) ?? undefined
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
-    return OptionalField_encode<K | null, K_JSON | null>(entity.rawValue, (entity: K | null): K_JSON | null => {
-        return Optional_encode<K, K_JSON>(entity, K_encode);
+export function S_encode(entity: S): S$JSON {
+    return OptionalField_encode<K | null, K$JSON | null>(entity.rawValue, (entity: K | null): K$JSON | null => {
+        return Optional_encode<K, K$JSON>(entity, K_encode);
     }) ?? null;
 }
 """
@@ -227,15 +227,15 @@ export type S = {
     rawValue: string[];
 } & TagRecord<"S">;
 """, """
-export type S_JSON = string[];
+export type S$JSON = string[];
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json as string[]
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue as string[];
 }
 """]
@@ -259,15 +259,15 @@ export type S = {
     rawValue: K;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K;
+export type S$JSON = K;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue;
 }
 """]
@@ -291,16 +291,16 @@ export type S = {
     rawValue: E;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = E_JSON;
+export type S$JSON = E$JSON;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: E_decode(json)
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
-    return entity.rawValue as E_JSON;
+export function S_encode(entity: S): S$JSON {
+    return entity.rawValue as E$JSON;
 }
 """
                        ]
@@ -325,15 +325,15 @@ export type S = {
     rawValue: K;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K_JSON;
+export type S$JSON = K$JSON;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: K_decode(json)
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return K_encode(entity.rawValue);
 }
 """
@@ -355,15 +355,15 @@ export type S = {
     rawValue: Date;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = string;
+export type S$JSON = string;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: Date_decode(json)
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return Date_encode(entity.rawValue);
 }
 """
@@ -389,15 +389,15 @@ export type S = {
     rawValue: K<Date>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K_JSON<string>;
+export type S$JSON = K$JSON<string>;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: K_decode<Date, string>(json, Date_decode)
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return K_encode<Date, string>(entity.rawValue, Date_encode);
 }
 """
@@ -424,16 +424,16 @@ export type S = {
     rawValue: K<E>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K_JSON<E_JSON>;
+export type S$JSON = K$JSON<E$JSON>;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
-        rawValue: K_decode<E, E_JSON>(json, E_decode)
+        rawValue: K_decode<E, E$JSON>(json, E_decode)
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
-    return entity.rawValue as K_JSON<E_JSON>;
+export function S_encode(entity: S): S$JSON {
+    return entity.rawValue as K$JSON<E$JSON>;
 }
 """
                        ]
@@ -457,15 +457,15 @@ export type S = {
     rawValue: K<number>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = K<number>;
+export type S$JSON = K<number>;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json as K<number>
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue as K<number>;
 }
 """
@@ -490,16 +490,16 @@ export type S<U> = {
     rawValue: K<U>;
 } & TagRecord<"S", [U]>;
 """, """
-export type S_JSON<U_JSON> = K_JSON<U_JSON>;
+export type S$JSON<U$JSON> = K$JSON<U$JSON>;
 """, """
-export function S_decode<U, U_JSON>(json: S_JSON<U_JSON>, U_decode: (json: U_JSON) => U): S<U> {
+export function S_decode<U, U$JSON>(json: S$JSON<U$JSON>, U_decode: (json: U$JSON) => U): S<U> {
     return {
-        rawValue: K_decode<U, U_JSON>(json, U_decode)
+        rawValue: K_decode<U, U$JSON>(json, U_decode)
     };
 }
 """, """
-export function S_encode<U, U_JSON>(entity: S<U>, U_encode: (entity: U) => U_JSON): S_JSON<U_JSON> {
-    return K_encode<U, U_JSON>(entity.rawValue, U_encode);
+export function S_encode<U, U$JSON>(entity: S<U>, U_encode: (entity: U) => U$JSON): S$JSON<U$JSON> {
+    return K_encode<U, U$JSON>(entity.rawValue, U_encode);
 }
 """
                        ]
@@ -519,18 +519,18 @@ export type S<T> = {
     rawValue: T;
 } & TagRecord<"S", [T]>;
 """, """
-export type S_JSON<T_JSON> = {
-    rawValue: T_JSON;
+export type S$JSON<T$JSON> = {
+    rawValue: T$JSON;
 };
 """, """
-export function S_decode<T, T_JSON>(json: S_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S<T> {
+export function S_decode<T, T$JSON>(json: S$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S<T> {
     const rawValue = T_decode(json.rawValue);
     return {
         rawValue: rawValue
     };
 }
 """, """
-export function S_encode<T, T_JSON>(entity: S<T>, T_encode: (entity: T) => T_JSON): S_JSON<T_JSON> {
+export function S_encode<T, T$JSON>(entity: S<T>, T_encode: (entity: T) => T$JSON): S$JSON<T$JSON> {
     const rawValue = T_encode(entity.rawValue);
     return {
         rawValue: rawValue
@@ -580,15 +580,15 @@ export type User_ID = {
     rawValue: string;
 } & TagRecord<"User_ID">;
 """, """
-export type User_ID_JSON = string;
+export type User_ID$JSON = string;
 """, """
-export function User_ID_decode(json: User_ID_JSON): User_ID {
+export function User_ID_decode(json: User_ID$JSON): User_ID {
     return {
         rawValue: json
     };
 }
 """, """
-export function User_ID_encode(entity: User_ID): User_ID_JSON {
+export function User_ID_encode(entity: User_ID): User_ID$JSON {
     return entity.rawValue;
 }
 """, """
@@ -597,12 +597,12 @@ export type User = {
     date: Date;
 } & TagRecord<"User">;
 """, """
-export type User_JSON = {
-    id: User_ID_JSON;
+export type User$JSON = {
+    id: User_ID$JSON;
     date: string;
 };
 """, """
-export function User_decode(json: User_JSON): User {
+export function User_decode(json: User$JSON): User {
     const id = User_ID_decode(json.id);
     const date = Date_decode(json.date);
     return {
@@ -611,7 +611,7 @@ export function User_decode(json: User_JSON): User {
     };
 }
 """, """
-export function User_encode(entity: User): User_JSON {
+export function User_encode(entity: User): User$JSON {
     const id = User_ID_encode(entity.id);
     const date = Date_encode(entity.date);
     return {
@@ -636,7 +636,7 @@ export type ID<G> = {
     rawValue: string;
 } & TagRecord<"ID", [G]>;
 """, """
-export type ID_JSON<G_JSON> = string;
+export type ID$JSON<G$JSON> = string;
 """]
         )
     }
@@ -656,15 +656,15 @@ export type S = {
     rawValue: number;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = number;
+export type S$JSON = number;
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     return {
         rawValue: json
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     return entity.rawValue;
 }
 """

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
@@ -56,12 +56,12 @@ export type S = {
     b: E;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: number;
-    b: E_JSON;
+    b: E$JSON;
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = json.a;
     const b = E_decode(json.b);
     return {
@@ -92,19 +92,19 @@ export type S = {
     e3?: E | null;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
-    e1?: E_JSON;
-    e2?: E_JSON | null;
-    e3?: E_JSON | null;
+export type S$JSON = {
+    e1?: E$JSON;
+    e2?: E$JSON | null;
+    e3?: E$JSON | null;
 };
 """, """
-export function S_decode(json: S_JSON): S {
-    const e1 = OptionalField_decode<E, E_JSON>(json.e1, E_decode);
-    const e2 = OptionalField_decode<E | null, E_JSON | null>(json.e2, (json: E_JSON | null): E | null => {
-        return Optional_decode<E, E_JSON>(json, E_decode);
+export function S_decode(json: S$JSON): S {
+    const e1 = OptionalField_decode<E, E$JSON>(json.e1, E_decode);
+    const e2 = OptionalField_decode<E | null, E$JSON | null>(json.e2, (json: E$JSON | null): E | null => {
+        return Optional_decode<E, E$JSON>(json, E_decode);
     });
-    const e3 = OptionalField_decode<E | null, E_JSON | null>(json.e3, (json: E_JSON | null): E | null => {
-        return Optional_decode<E, E_JSON>(json, E_decode);
+    const e3 = OptionalField_decode<E | null, E$JSON | null>(json.e3, (json: E$JSON | null): E | null => {
+        return Optional_decode<E, E$JSON>(json, E_decode);
     });
     return {
         e1: e1,
@@ -148,14 +148,14 @@ struct S {
             ,
             typeSelector: .name("S"),
             expecteds: ["""
-export function S_decode(json: S_JSON): S {
-    const e1 = Array_decode<E, E_JSON>(json.e1, E_decode);
-    const e2 = Array_decode<E[], E_JSON[]>(json.e2, (json: E_JSON[]): E[] => {
-        return Array_decode<E, E_JSON>(json, E_decode);
+export function S_decode(json: S$JSON): S {
+    const e1 = Array_decode<E, E$JSON>(json.e1, E_decode);
+    const e2 = Array_decode<E[], E$JSON[]>(json.e2, (json: E$JSON[]): E[] => {
+        return Array_decode<E, E$JSON>(json, E_decode);
     });
-    const e3 = Array_decode<E[][], E_JSON[][]>(json.e3, (json: E_JSON[][]): E[][] => {
-        return Array_decode<E[], E_JSON[]>(json, (json: E_JSON[]): E[] => {
-            return Array_decode<E, E_JSON>(json, E_decode);
+    const e3 = Array_decode<E[][], E$JSON[][]>(json.e3, (json: E$JSON[][]): E[][] => {
+        return Array_decode<E[], E$JSON[]>(json, (json: E$JSON[]): E[] => {
+            return Array_decode<E, E$JSON>(json, E_decode);
         });
     });
     return {
@@ -199,19 +199,19 @@ struct S {
 """,
             typeSelector: .name("S"),
             expecteds: ["""
-export function S_decode(json: S_JSON): S {
-    const e1 = OptionalField_decode<E[], E_JSON[]>(json.e1, (json: E_JSON[]): E[] => {
-        return Array_decode<E, E_JSON>(json, E_decode);
+export function S_decode(json: S$JSON): S {
+    const e1 = OptionalField_decode<E[], E$JSON[]>(json.e1, (json: E$JSON[]): E[] => {
+        return Array_decode<E, E$JSON>(json, E_decode);
     });
-    const e2 = Array_decode<E | null, E_JSON | null>(json.e2, (json: E_JSON | null): E | null => {
-        return Optional_decode<E, E_JSON>(json, E_decode);
+    const e2 = Array_decode<E | null, E$JSON | null>(json.e2, (json: E$JSON | null): E | null => {
+        return Optional_decode<E, E$JSON>(json, E_decode);
     });
-    const e3 = OptionalField_decode<E[], E_JSON[]>(json.e3, (json: E_JSON[]): E[] => {
-        return Array_decode<E, E_JSON>(json, E_decode);
+    const e3 = OptionalField_decode<E[], E$JSON[]>(json.e3, (json: E$JSON[]): E[] => {
+        return Array_decode<E, E$JSON>(json, E_decode);
     });
-    const e4 = OptionalField_decode<(E | null)[], (E_JSON | null)[]>(json.e4, (json: (E_JSON | null)[]): (E | null)[] => {
-        return Array_decode<E | null, E_JSON | null>(json, (json: E_JSON | null): E | null => {
-            return Optional_decode<E, E_JSON>(json, E_decode);
+    const e4 = OptionalField_decode<(E | null)[], (E$JSON | null)[]>(json.e4, (json: (E$JSON | null)[]): (E | null)[] => {
+        return Array_decode<E | null, E$JSON | null>(json, (json: E$JSON | null): E | null => {
+            return Optional_decode<E, E$JSON>(json, E_decode);
         });
     });
     return {
@@ -240,19 +240,19 @@ export type S = {
     e1: Set<E>;
 } & TagRecord<"S">;
 
-export type S_JSON = {
-    e1: E_JSON[];
+export type S$JSON = {
+    e1: E$JSON[];
 };
 
-export function S_decode(json: S_JSON): S {
-    const e1 = Set_decode<E, E_JSON>(json.e1, E_decode);
+export function S_decode(json: S$JSON): S {
+    const e1 = Set_decode<E, E$JSON>(json.e1, E_decode);
     return {
         e1: e1
     };
 }
 
-export function S_encode(entity: S): S_JSON {
-    const e1 = Set_encode<E, E_JSON>(entity.e1, identity);
+export function S_encode(entity: S): S$JSON {
+    const e1 = Set_encode<E, E$JSON>(entity.e1, identity);
     return {
         e1: e1
     };
@@ -279,23 +279,23 @@ export type S = {
     e3: Map<string, number>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     e1: {
-        [key: string]: E_JSON;
+        [key: string]: E$JSON;
     };
     e2: {
-        [key: string]: (E_JSON | null)[];
+        [key: string]: (E$JSON | null)[];
     };
     e3: {
         [key: string]: number;
     };
 };
 """, """
-export function S_decode(json: S_JSON): S {
-    const e1 = Dictionary_decode<E, E_JSON>(json.e1, E_decode);
-    const e2 = Dictionary_decode<(E | null)[], (E_JSON | null)[]>(json.e2, (json: (E_JSON | null)[]): (E | null)[] => {
-        return Array_decode<E | null, E_JSON | null>(json, (json: E_JSON | null): E | null => {
-            return Optional_decode<E, E_JSON>(json, E_decode);
+export function S_decode(json: S$JSON): S {
+    const e1 = Dictionary_decode<E, E$JSON>(json.e1, E_decode);
+    const e2 = Dictionary_decode<(E | null)[], (E$JSON | null)[]>(json.e2, (json: (E$JSON | null)[]): (E | null)[] => {
+        return Array_decode<E | null, E$JSON | null>(json, (json: E$JSON | null): E | null => {
+            return Optional_decode<E, E$JSON>(json, E_decode);
         });
     });
     const e3 = Dictionary_decode<number, number>(json.e3, identity);
@@ -306,9 +306,9 @@ export function S_decode(json: S_JSON): S {
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
-    const e1 = Dictionary_encode<E, E_JSON>(entity.e1, identity);
-    const e2 = Dictionary_encode<(E | null)[], (E_JSON | null)[]>(entity.e2, identity);
+export function S_encode(entity: S): S$JSON {
+    const e1 = Dictionary_encode<E, E$JSON>(entity.e1, identity);
+    const e2 = Dictionary_encode<(E | null)[], (E$JSON | null)[]>(entity.e2, identity);
     const e3 = Dictionary_encode<number, number>(entity.e3, identity);
     return {
         e1: e1,
@@ -332,7 +332,7 @@ export type S = {
     a: Map<string, Map<string, number>>;
 } & TagRecord<"S">;
 """, """
-export type S_JSON = {
+export type S$JSON = {
     a: {
         [key: string]: {
             [key: string]: number;
@@ -340,7 +340,7 @@ export type S_JSON = {
     };
 };
 """, """
-export function S_decode(json: S_JSON): S {
+export function S_decode(json: S$JSON): S {
     const a = Dictionary_decode<Map<string, number>, {
         [key: string]: number;
     }>(json.a, (json: {
@@ -353,7 +353,7 @@ export function S_decode(json: S_JSON): S {
     };
 }
 """, """
-export function S_encode(entity: S): S_JSON {
+export function S_encode(entity: S): S$JSON {
     const a = Dictionary_encode<Map<string, number>, {
         [key: string]: number;
     }>(entity.a, (entity: Map<string, number>): {

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateTypeAliasTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateTypeAliasTests.swift
@@ -12,7 +12,7 @@ export type A = number;
 """
             ],
             unexpecteds: ["""
-export type A_JSON
+export type A$JSON
 """]
         )
     }
@@ -28,9 +28,9 @@ typealias A = S
             expecteds: ["""
 export type A = S;
 """, """
-export type A_JSON = S_JSON;
+export type A$JSON = S$JSON;
 """, """
-export function A_decode(json: A_JSON): A {
+export function A_decode(json: A$JSON): A {
     return S_decode(json);
 }
 """]
@@ -47,14 +47,14 @@ typealias A<T> = S<T>
         expecteds: ["""
 export type A<T> = S<T>;
 """, """
-export type A_JSON<T_JSON> = S_JSON<T_JSON>;
+export type A$JSON<T$JSON> = S$JSON<T$JSON>;
 """, """
-export function A_decode<T, T_JSON>(json: A_JSON<T_JSON>, T_decode: (json: T_JSON) => T): A<T> {
-    return S_decode<T, T_JSON>(json, T_decode);
+export function A_decode<T, T$JSON>(json: A$JSON<T$JSON>, T_decode: (json: T$JSON) => T): A<T> {
+    return S_decode<T, T$JSON>(json, T_decode);
 }
 """, """
-export function A_encode<T, T_JSON>(entity: A<T>, T_encode: (entity: T) => T_JSON): A_JSON<T_JSON> {
-    return S_encode<T, T_JSON>(entity, T_encode);
+export function A_encode<T, T$JSON>(entity: A<T>, T_encode: (entity: T) => T$JSON): A$JSON<T$JSON> {
+    return S_encode<T, T$JSON>(entity, T_encode);
 }
 """
         ])
@@ -71,9 +71,9 @@ typealias A<T> = S
         expecteds: ["""
 export type A<T> = S;
 """, """
-export type A_JSON<T_JSON> = S_JSON;
+export type A$JSON<T$JSON> = S$JSON;
 """, """
-export function A_decode<T, T_JSON>(json: A_JSON<T_JSON>, T_decode: (json: T_JSON) => T): A<T> {
+export function A_decode<T, T$JSON>(json: A$JSON<T$JSON>, T_decode: (json: T$JSON) => T): A<T> {
     return S_decode(json);
 }
 """
@@ -93,14 +93,14 @@ struct S {
             expecteds: ["""
 export type S_A<T> = E<T>;
 """, """
-export type S_A_JSON<T_JSON> = E_JSON<T_JSON>;
+export type S_A$JSON<T$JSON> = E$JSON<T$JSON>;
 """, """
-export function S_A_decode<T, T_JSON>(json: S_A_JSON<T_JSON>, T_decode: (json: T_JSON) => T): S_A<T> {
-    return E_decode<T, T_JSON>(json, T_decode);
+export function S_A_decode<T, T$JSON>(json: S_A$JSON<T$JSON>, T_decode: (json: T$JSON) => T): S_A<T> {
+    return E_decode<T, T$JSON>(json, T_decode);
 }
 """, """
-export function S_A_encode<T, T_JSON>(entity: S_A<T>, T_encode: (entity: T) => T_JSON): S_A_JSON<T_JSON> {
-    return E_encode<T, T_JSON>(entity, T_encode);
+export function S_A_encode<T, T$JSON>(entity: S_A<T>, T_encode: (entity: T) => T$JSON): S_A$JSON<T$JSON> {
+    return E_encode<T, T$JSON>(entity, T_encode);
 }
 """
             ]
@@ -152,16 +152,16 @@ export type User = {
     id: User_ID;
 } & TagRecord<"User">;
 """, """
-export type User_JSON = {
-    id: User_ID_JSON;
+export type User$JSON = {
+    id: User_ID$JSON;
 };
 """, """
 export type User_ID = GenericID<User>;
 """, """
-export type User_ID_JSON = GenericID_JSON<User_JSON>;
+export type User_ID$JSON = GenericID$JSON<User$JSON>;
 """, """
-export function User_ID_decode(json: User_ID_JSON): User_ID {
-    return GenericID_decode<User, User_JSON>(json, User_decode);
+export function User_ID_decode(json: User_ID$JSON): User_ID {
+    return GenericID_decode<User, User$JSON>(json, User_decode);
 }
 """
             ]

--- a/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
+++ b/Tests/CodableToTypeScriptTests/HelperLibraryTests.swift
@@ -16,45 +16,45 @@ export function identity<T>(json: T): T {
     return json;
 }
 """, """
-export function OptionalField_decode<T, T_JSON>(json: T_JSON | undefined, T_decode: (json: T_JSON) => T): T | undefined {
+export function OptionalField_decode<T, T$JSON>(json: T$JSON | undefined, T_decode: (json: T$JSON) => T): T | undefined {
     if (json === undefined) return undefined;
     return T_decode(json);
 }
 """, """
-export function OptionalField_encode<T, T_JSON>(entity: T | undefined, T_encode: (entity: T) => T_JSON): T_JSON | undefined {
+export function OptionalField_encode<T, T$JSON>(entity: T | undefined, T_encode: (entity: T) => T$JSON): T$JSON | undefined {
     if (entity === undefined) return undefined;
     return T_encode(entity);
 }
 """, """
-export function Optional_decode<T, T_JSON>(json: T_JSON | null, T_decode: (json: T_JSON) => T): T | null {
+export function Optional_decode<T, T$JSON>(json: T$JSON | null, T_decode: (json: T$JSON) => T): T | null {
     if (json === null) return null;
     return T_decode(json);
 }
 """, """
-export function Optional_encode<T, T_JSON>(entity: T | null, T_encode: (entity: T) => T_JSON): T_JSON | null {
+export function Optional_encode<T, T$JSON>(entity: T | null, T_encode: (entity: T) => T$JSON): T$JSON | null {
     if (entity === null) return null;
     return T_encode(entity);
 }
 """, """
-export function Array_decode<T, T_JSON>(json: T_JSON[], T_decode: (json: T_JSON) => T): T[] {
+export function Array_decode<T, T$JSON>(json: T$JSON[], T_decode: (json: T$JSON) => T): T[] {
     return json.map(T_decode);
 }
 """, """
-export function Array_encode<T, T_JSON>(entity: T[], T_encode: (entity: T) => T_JSON): T_JSON[] {
+export function Array_encode<T, T$JSON>(entity: T[], T_encode: (entity: T) => T$JSON): T$JSON[] {
     return entity.map(T_encode);
 }
 """, """
-export function Set_decode<T, T_JSON>(json: T_JSON[], T_decode: (json: T_JSON) => T): Set<T> {
+export function Set_decode<T, T$JSON>(json: T$JSON[], T_decode: (json: T$JSON) => T): Set<T> {
     return new Set(json.map(T_decode));
 }
 """, """
-export function Set_encode<T, T_JSON>(entity: Set<T>, T_encode: (entity: T) => T_JSON): T_JSON[] {
+export function Set_encode<T, T$JSON>(entity: Set<T>, T_encode: (entity: T) => T$JSON): T$JSON[] {
     return [... entity].map(T_encode);
 }
 """, """
-export function Dictionary_decode<T, T_JSON>(json: {
-    [key: string]: T_JSON;
-}, T_decode: (json: T_JSON) => T): Map<string, T> {
+export function Dictionary_decode<T, T$JSON>(json: {
+    [key: string]: T$JSON;
+}, T_decode: (json: T$JSON) => T): Map<string, T> {
     const entity = new Map<string, T>();
     for (const k in json) {
         if (json.hasOwnProperty(k)) {
@@ -64,11 +64,11 @@ export function Dictionary_decode<T, T_JSON>(json: {
     return entity;
 }
 """, """
-export function Dictionary_encode<T, T_JSON>(entity: Map<string, T>, T_encode: (entity: T) => T_JSON): {
-    [key: string]: T_JSON;
+export function Dictionary_encode<T, T$JSON>(entity: Map<string, T>, T_encode: (entity: T) => T$JSON): {
+    [key: string]: T$JSON;
 } {
     const json: {
-        [key: string]: T_JSON;
+        [key: string]: T$JSON;
     } = {};
     for (const k in entity.keys()) {
         json[k] = T_encode(entity.get(k) !!);


### PR DESCRIPTION
以下のようなコードにおいて、重複したシンボルが生成されるという問題があります。

```swift
struct Foo {
  struct JSON {}
  …
}
```

`Foo`のTS側JSON型として`Foo_JSON`が。
`Foo.JSON`のTS側Entity型として`Foo_JSON`が生成され、衝突します。

この問題の原因は、ネームスペース結合の記号とJSON型のSuffix結合の記号が同一の`_`であることだと思います。
片方の結合に用いる記号を変更することで回避ができます。

もちろん、Swift側の型名で`_`や`$`が使われていた場合に似たような壊れが起こると思いますが、それは特殊なケースなので諦めます。
