### PR TITLE
シンボル収集の意味的なズレの修正

### DIFF
--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -57,16 +57,11 @@ public final class PackageGenerator {
         // collect symbols included in for each swift source file
         for module in context.modules.filter({ $0 !== context.swiftModule }) {
             for source in module.sources {
-                for type in source.types {
-                    guard
-                        let typeConverter = try? codeGenerator.converter(for: type.declaredInterfaceType),
-                        let declaredNames = try? typeConverter.decls().compactMap(\.declaredName)
-                    else {
-                        continue
-                    }
-                    for declaredName in declaredNames {
-                        symbolToSource[declaredName] = source
-                    }
+                guard let tsSource = try? codeGenerator.convert(source: source) else {
+                    continue
+                }
+                for declaredName in tsSource.memberDeclaredNames {
+                    symbolToSource[declaredName] = source
                 }
             }
         }


### PR DESCRIPTION
機能的な変更ではなく、リファクタリングの意味合いの修正です。

https://github.com/omochi/CodableToTypeScript/pull/118 で導入されたPackageGeneratorのシンボル収集プロセスについてです。

ソースコードの変換処理はファイル単位で行われており、ファイル単位での成功と失敗があります。
シンボル収集する際も、変換に失敗するファイルに含まれたシンボルは、結果的には参照できないので収集する必要がありません。

既存の実装は、ファイル内ふ含まれるSwift型1つずつについてシンボル収集するロジックになっていました。
これを、実際の変換処理に合わせてファイル単位の処理に書き換えます。
中の処理を展開するとやっていることは全く同じなので、機能的な変化はありません。

`codeGenerator.convert`の呼び出しが2箇所になって、同じ処理をしていることがわかりやすくなりました。

----

ついでにこの問題に気づくきっかけになったテストを追加しています。