### PR TITLE
同じソースファイルが複数回生成されてしまうことがある問題の修正

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
-        "version" : "600.0.0"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
+++ b/Sources/CodableToTypeScript/Generator/PackageGenerator.swift
@@ -82,15 +82,10 @@ public final class PackageGenerator {
         }
 
         var targetSources: [SourceFile] = modules.flatMap(\.sources)
-        var generatedSources: Set<SourceFile> = []
         var generatedEntries: [PackageEntry] = [helperEntry]
 
         try withErrorCollector { collect in
             while let source = targetSources.popLast() {
-                guard generatedSources.insert(source).inserted else {
-                    continue
-                }
-
                 collect(at: source.file.lastPathComponent) {
                     let tsSource = try convertedSources[source] ?? (codeGenerator.convert(source: source))
 
@@ -116,7 +111,7 @@ public final class PackageGenerator {
                     tsSource.replaceImportDecls(imports)
                     for importedSymbolName in imports.flatMap(\.names) {
                         // Add a file that is used but not included in the generation target
-                        if let source = symbolToSource[importedSymbolName], !generatedSources.contains(source) {
+                        if let source = symbolToSource[importedSymbolName], !targetSources.contains(source) {
                             targetSources.append(source)
                         }
                     }


### PR DESCRIPTION
## 課題

PackageGeneratorにおいて、特定の状況において同じソースファイルが複数回生成されるという問題がありました。

以下の状況で再現します。

- AとBのファイルがあり、どちらも生成対象として指定されている
- BはAに依存している
- 生成処理がBから開始される（生成処理は入力とは逆順に行われるため、A, Bの順で入力された場合）

同じソースファイルが複数回処理された場合、`didConvertSource`がその回数分呼び出されてしまうため、外部から別途TSコードをPackageEntryに注入していた場合、そのコードが重複してしまいます。
（PackageEntryのもつ`source`が参照型であることと、シンボルテーブル生成時の結果を使い回す実装が組み合わさって起こる）


## 原因

現在のPackageGeneratorの処理は以下のようになっています。

1. 読み込んだすべてのSwiftコードに関してTSコードを生成し、シンボルテーブルを作成する
2. 生成対象に指定されたファイルをすべて生成対象スタックに積む
3. 生成対象スタックから1つ取り出してTSコードを生成（1で生成したキャッシュを使う
）し、importされているシンボルを調べる。その中に未生成のものがあればそれを生成対象スタックに追加
4. 生成対象スタックがなくなるまで繰り替えす

この際、3で未生成のものかどうかを`generatedSources`という集合で管理していましたが、`generatedSources`に含まれていないけど生成対象スタックに含まている、というケースを見逃していました。
そのケースの場合、生成対象スタックには同じソースファイルが複数積まれることが生じえます。

例えば上のA,Bのファイルのケースの場合の生成対象スタックの変化は以下の形になります。

| STEP | 生成対象スタックの状態 | 状況 |
| --- | --- | --- |
| 1 | [A.swift, B.swift] | 初期状態 |
| 2 | [A.swift] | 末尾から処理。Bを処理中 |
| 3 | [A.swift, A.swift] | Bの依存にAが含まれ、かつ`generatedSources`にAは含まれないので、Aを追加 |

A.swiftが2回処理されることになりました。

## 修正方針

スタックから値を取り出した際、それが`generatedSources`に含まれている場合はスキップできるようにします。