### PR TITLE
自動生成する変数名が既存の名前と衝突しないようにする

### DIFF
--- a/Sources/CodableToTypeScript/Basic/NameProvider.swift
+++ b/Sources/CodableToTypeScript/Basic/NameProvider.swift
@@ -7,8 +7,12 @@ struct NameProvider {
 
     mutating func register(signature: TSFunctionDecl) {
         for param in signature.params {
-            used.insert(param.name)
+            register(name: param.name)
         }
+    }
+
+    mutating func register(name: String) {
+        used.insert(name)
     }
 
     mutating func provide(base: String) -> String {

--- a/Sources/CodableToTypeScript/Basic/NameProvider.swift
+++ b/Sources/CodableToTypeScript/Basic/NameProvider.swift
@@ -1,0 +1,36 @@
+import TypeScriptAST
+
+struct NameProvider {
+    init() {}
+
+    private var used: Set<String> = []
+
+    mutating func register(signature: TSFunctionDecl) {
+        for param in signature.params {
+            used.insert(param.name)
+        }
+    }
+
+    mutating func provide(base: String) -> String {
+        if let name = provideIfUnused(name: base) {
+            return name
+        }
+
+        var i = 2
+        while true {
+            let cand = "\(base)\(i)"
+            if let name = provideIfUnused(name: cand) {
+                return name
+            }
+            i += 1
+        }
+    }
+
+    mutating func provideIfUnused(name: String) -> String? {
+        if used.contains(name) {
+            return nil
+        }
+        used.insert(name)
+        return name
+    }
+}

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -326,6 +326,7 @@ private struct DecodeObjFuncGen {
                 )
             )
             block.append(j)
+            nameProvider.register(name: "j")
         }
 
         var names: [String: String] = [:]
@@ -475,6 +476,7 @@ private struct EncodeObjFuncGen {
                 initializer: TSMemberExpr(base: TSIdentExpr.entity, name: element.name)
             )
             code.append(e)
+            nameProvider.register(name: "e")
         }
 
         var names: [String: String] = [:]

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -339,4 +339,32 @@ export function E_decode(json: E$JSON): E {
             ]
         )
     }
+
+    func testConflictPropertyName() throws {
+        try assertGenerate(
+            source: """
+enum E<T> {
+    case entity(entity: String, json: String)
+    case json
+    case t(T)
+}
+""",
+            expecteds: [
+                // decode
+"""
+const json2 = j.json;
+""", """
+json: json2
+""",
+
+// encode
+"""
+const entity2 = e.entity;
+""", """
+entity: entity2,
+"""
+            ],
+            unexpecteds: []
+        )
+    }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -344,7 +344,7 @@ export function E_decode(json: E$JSON): E {
         try assertGenerate(
             source: """
 enum E<T> {
-    case entity(entity: String, json: String)
+    case entity(entity: String, json: String, e: String, j: String)
     case json
     case t(T)
 }
@@ -354,14 +354,22 @@ enum E<T> {
 """
 const json2 = j.json;
 """, """
+const j2 = j.j;
+""", """
 json: json2
+""", """
+j: j2
 """,
 
 // encode
 """
 const entity2 = e.entity;
 """, """
+const e2 = e.e;
+""", """
 entity: entity2,
+""", """
+e: e2
 """
             ],
             unexpecteds: []

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
@@ -430,4 +430,38 @@ export type S = {
             ]
         )
     }
+
+    func testConflictPropertyName() throws {
+        try assertGenerate(
+            source: """
+struct S<T> {
+    var entity: String
+    var json: String
+    var t: T
+}
+""",
+            expecteds: ["""
+export type S<T> = {
+    entity: string;
+    json: string;
+    t: T;
+} & TagRecord<"S", [T]>;
+""",
+                        // decode
+"""
+const json2 = json.json;
+""", """
+json: json2,
+""",
+
+                        // encode
+"""
+const entity2 = entity.entity;
+""", """
+entity: entity2,
+"""
+            ],
+            unexpecteds: []
+        )
+    }
 }

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateStructTests.swift
@@ -440,21 +440,15 @@ struct S<T> {
     var t: T
 }
 """,
-            expecteds: ["""
-export type S<T> = {
-    entity: string;
-    json: string;
-    t: T;
-} & TagRecord<"S", [T]>;
-""",
-                        // decode
+            expecteds: [
+                // decode
 """
 const json2 = json.json;
 """, """
 json: json2,
 """,
 
-                        // encode
+// encode
 """
 const entity2 = entity.entity;
 """, """


### PR DESCRIPTION
トランスパイルするSwiftの型が `var entity` のようなプロパティを持っていると、
コード生成するときにJSの関数の引数の `entity` と、
プロパティに対応して生成されるローカル変数の `const entity` が衝突して、
TypeScriptとしてコンパイル不可能になってしまう。

このパッチはこの問題を回避する。

ローカル変数を生成するときに既存の名前として使用済みかどうかを調べて、
使用済みであれば代わりに連番をつけた名前を使用する。

