### PR TITLE
空のenumのトランスパイル先としてneverではなくvoidを選べるようにする

### DIFF
--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -79,11 +79,15 @@ public struct EnumConverter: TypeConverter {
                 type: TSIdentType.never
             )
         case .void:
+            var type: any TSType = TSIdentType.void
+            if target == .entity {
+                type = try attachTag(to: type)
+            }
             return TSTypeDecl(
                 modifiers: [.export],
                 name: try name(for: target),
                 genericParams: genericParams,
-                type: try attachTag(to: TSIdentType.void)
+                type: type
             )
         case .string:
             let items: [any TSType] = decl.caseElements.map { (ce) in

--- a/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
+++ b/Sources/CodableToTypeScript/TypeConverter/EnumConverter.swift
@@ -2,14 +2,30 @@ import SwiftTypeReader
 import TypeScriptAST
 
 public struct EnumConverter: TypeConverter {
-    public init(generator: CodeGenerator, `enum`: EnumType) {
+    public enum EmptyEnumStrategy {
+        case never
+        case void
+
+        func toKind() -> Kind {
+            switch self {
+            case .never: return .never
+            case .void: return .void
+            }
+        }
+    }
+
+    public init(
+        generator: CodeGenerator,
+        `enum`: EnumType,
+        emptyEnumStrategy: EmptyEnumStrategy = .never
+    ) {
         self.generator = generator
         self.`enum` = `enum`
 
         let decl = `enum`.decl
 
         if decl.caseElements.isEmpty {
-            self.kind = .never
+            self.kind = emptyEnumStrategy.toKind()
             return
         }
 
@@ -37,6 +53,7 @@ public struct EnumConverter: TypeConverter {
 
     enum Kind {
         case never
+        case void
         case string
         case int
         case normal
@@ -60,6 +77,13 @@ public struct EnumConverter: TypeConverter {
                 name: try name(for: target),
                 genericParams: genericParams,
                 type: TSIdentType.never
+            )
+        case .void:
+            return TSTypeDecl(
+                modifiers: [.export],
+                name: try name(for: target),
+                genericParams: genericParams,
+                type: try attachTag(to: TSIdentType.void)
             )
         case .string:
             let items: [any TSType] = decl.caseElements.map { (ce) in
@@ -117,13 +141,7 @@ public struct EnumConverter: TypeConverter {
 
         switch target {
         case .entity:
-            let tag = try generator.tagRecord(
-                name: name,
-                genericArgs: try self.genericParams().map {
-                    try TSIdentType($0.name(for: .entity))
-                }
-            )
-            type = TSIntersectionType(type, tag)
+            type = try attachTag(to: type)
         case .json: break
         }
 
@@ -133,6 +151,18 @@ public struct EnumConverter: TypeConverter {
             genericParams: genericParams,
             type: type
         )
+    }
+
+    private func attachTag(to type: any TSType) throws -> any TSType {
+        let target = GenerationTarget.entity
+        let name = try self.name(for: target)
+        let tag = try generator.tagRecord(
+            name: name,
+            genericArgs: try self.genericParams().map {
+                try TSIdentType($0.name(for: target))
+            }
+        )
+        return TSIntersectionType(type, tag)
     }
 
     private func transpile(
@@ -184,6 +214,7 @@ public struct EnumConverter: TypeConverter {
     public func hasDecode() throws -> Bool {
         switch kind {
         case .never: return false
+        case .void: return false
         case .string: return false
         case .int: return true
         case .normal: return true
@@ -192,7 +223,7 @@ public struct EnumConverter: TypeConverter {
 
     public func decodeDecl() throws -> TSFunctionDecl? {
         switch kind {
-        case .never, .string:
+        case .never, .void, .string:
             return nil
         case .int:
             return try DecodeIntFuncGen(
@@ -211,6 +242,7 @@ public struct EnumConverter: TypeConverter {
     public func hasEncode() throws -> Bool {
         switch kind {
         case .never: return false
+        case .void: return false
         case .string: return false
         case .int: return true
         case .normal: break
@@ -238,7 +270,7 @@ public struct EnumConverter: TypeConverter {
 
     public func encodeDecl() throws -> TSFunctionDecl? {
         switch kind {
-        case .never, .string:
+        case .never, .void, .string:
             return nil
         case .int:
             return try EncodeIntFuncGen(

--- a/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
+++ b/Tests/CodableToTypeScriptTests/Generate/GenerateEnumTests.swift
@@ -375,4 +375,43 @@ e: e2
             unexpecteds: []
         )
     }
+
+    func testEmptyEnumNever() throws {
+        try assertGenerate(
+            source: """
+enum E {}
+""",
+            expecteds: [
+"""
+export type E = never;
+"""
+            ]
+        )
+    }
+
+    func testEmptyEnumVoid() throws {
+        let typeConverterProvider = TypeConverterProvider { (gen, ty) in
+            guard let cnv = try TypeConverterProvider.defaultConverter(generator: gen, type: ty) else {
+                return nil
+            }
+
+            if let cnv = cnv as? EnumConverter {
+                return EnumConverter(generator: gen, enum: cnv.enum, emptyEnumStrategy: .void)
+            }
+
+            return nil
+        }
+
+        try assertGenerate(
+            source: """
+enum E {}
+""",
+            typeConverterProvider: typeConverterProvider,
+            expecteds: [
+"""
+export type E = void & TagRecord<"E">;
+"""
+            ]
+        )
+    }
 }


### PR DESCRIPTION
従来、空のenumはneverにトランスパイルしていた。
しかしこれには型タグが付いていないという問題があり、
以下のようなSwiftコードで問題があった。

```swift
struct GenericID<Tag> { ... }

enum FooTag {}
typealias FooID = GenericID<FooTag>
```

一見、neverに型タグを付ければ良さそうだが、
ここでTypeScriptコンパイラが特殊な挙動をしてしまい、
仮に以下のようにコード生成しても

```ts
type FooTag = never & TagRecord<"FooTag">;
type FooID = GenericID<FooTag>;
```

`FooID` のタグは期待される
```
"GenericID", ["FooTag"]
```
とはならず
```
"GenericID", [string]
```
となってしまう。
これではタグ型がタグとして機能しないので困る。

そこでこのパッチでは、代わりに

```ts
type FooTag = void & TagRecord<"FooTag">;
```

とトランスパイルするモードを追加する。
これだと期待通りタグが機能する。

従来の never への変換は、
それはそれで型の値が存在しないことを意味する点で望ましいため、
仕様変更をせずにデフォルトの挙動として維持する。

新しいvoidへの変換は
`EnumConverter` に指定するAPIオプションとして提供する。

ユーザーはこれを custom type converter を使用して、
特定の enum 型の変換の挙動として指定することができる。

またこの際、
全ての enum 型についての挙動を変更することもできるように、
デフォルトの type converter 選択を直接再利用できるようにAPI化した。
テストケースではそのようなセットアップをした。